### PR TITLE
Modify JWT authentication to attain token from cookies

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/authentication/JwtFilter.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/authentication/JwtFilter.java
@@ -5,6 +5,7 @@ import com.sublinks.sublinksapi.person.repositories.PersonRepository;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -29,15 +30,32 @@ public class JwtFilter extends OncePerRequestFilter {
       final HttpServletResponse response,
       final FilterChain filterChain) throws ServletException, IOException {
 
-    final String authorizationHeader = request.getHeader("Authorization");
+    String authorizingToken = request.getHeader("Authorization");
+
+    var cookies = request.getCookies();
+
+    if (authorizingToken == null && request.getCookies() != null) {
+      for (Cookie cookie : request.getCookies()) {
+
+        if (cookie.getName().equals("jwt")) {
+          authorizingToken = cookie.getValue();
+          break;
+        }
+      }
+
+    }
 
     String token = null;
     String userName = null;
 
     try {
-      if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-        token = authorizationHeader.substring(7);
-        userName = jwtUtil.extractUsername(token);
+      if (authorizingToken != null) {
+        if (authorizingToken.startsWith("Bearer ")) {
+          token = authorizingToken.substring(7);
+        } else {
+          token = authorizingToken;
+        }
+          userName = jwtUtil.extractUsername(token);
       }
     } catch (ExpiredJwtException ex) {
       response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
@@ -50,7 +68,8 @@ public class JwtFilter extends OncePerRequestFilter {
       }
 
       if (jwtUtil.validateToken(token, person.get())) {
-        final JwtPerson authenticationToken = new JwtPerson(person.get(), person.get().getAuthorities());
+        final JwtPerson authenticationToken = new JwtPerson(person.get(),
+            person.get().getAuthorities());
         authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(authenticationToken);
       }

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/site/controllers/SiteController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/site/controllers/SiteController.java
@@ -36,7 +36,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.Optional;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.http.HttpStatus;
@@ -163,7 +162,6 @@ public class SiteController extends AbstractLemmyApiController {
       final JwtPerson principal) {
 
     // @todo: Check permission on federation change
-
 
     final Person person = getPersonOrThrowUnauthorized(principal);
 


### PR DESCRIPTION
Expanded the JWT authentication method in JwtFilter to also search for JWT tokens in the cookies if it is not found in the "Authorization" header of the request. A token is assigned either from the header or from the cookies, depending on which contains the JWT. Also removed unnecessary import in the SiteController class.