### PR TITLE
Refactor Captcha service and introduce complexity level setting

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
@@ -17,7 +17,7 @@ import com.sublinks.sublinksapi.api.lemmy.v3.user.models.SuccessResponse;
 import com.sublinks.sublinksapi.api.lemmy.v3.user.models.UpdateTotp;
 import com.sublinks.sublinksapi.api.lemmy.v3.user.models.UpdateTotpResponse;
 import com.sublinks.sublinksapi.api.lemmy.v3.user.models.VerifyEmailResponse;
-import com.sublinks.sublinksapi.api.lemmy.v3.user.services.CaptchaService;
+import com.sublinks.sublinksapi.person.services.CaptchaService;
 import com.sublinks.sublinksapi.authorization.enums.RolePermission;
 import com.sublinks.sublinksapi.authorization.services.RoleAuthorizingService;
 import com.sublinks.sublinksapi.instance.dto.InstanceConfig;

--- a/src/main/java/com/sublinks/sublinksapi/instance/services/InstanceConfigService.java
+++ b/src/main/java/com/sublinks/sublinksapi/instance/services/InstanceConfigService.java
@@ -29,6 +29,5 @@ public class InstanceConfigService {
 
     instanceConfigRepository.save(instance);
     instanceConfigUpdatedPublisher.publish(instance);
-
   }
 }

--- a/src/main/java/com/sublinks/sublinksapi/person/listeners/InstanceConfigUpdatedListener.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/listeners/InstanceConfigUpdatedListener.java
@@ -1,0 +1,23 @@
+package com.sublinks.sublinksapi.person.listeners;
+
+import com.sublinks.sublinksapi.instance.events.InstanceConfigUpdatedEvent;
+import com.sublinks.sublinksapi.person.services.CaptchaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class InstanceConfigUpdatedListener implements
+    ApplicationListener<InstanceConfigUpdatedEvent> {
+
+  private final CaptchaService captchaService;
+
+  @Override
+  public void onApplicationEvent(InstanceConfigUpdatedEvent event) {
+
+    captchaService.recreateAllCaptchas();
+  }
+}

--- a/src/main/java/com/sublinks/sublinksapi/person/repositories/CaptchaRepository.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/repositories/CaptchaRepository.java
@@ -14,5 +14,7 @@ public interface CaptchaRepository extends JpaRepository<Captcha, Long> {
 
   Optional<Captcha> findByWordIs(String word);
 
+  void deleteAllByLockedFalse();
+
   long countAllByLockedFalse();
 }

--- a/src/main/java/com/sublinks/sublinksapi/person/scheduling/CaptchaScheduler.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/scheduling/CaptchaScheduler.java
@@ -1,15 +1,16 @@
-package com.sublinks.sublinksapi.api.lemmy.v3.user.scheduling;
+package com.sublinks.sublinksapi.person.scheduling;
 
+import com.sublinks.sublinksapi.instance.models.LocalInstanceContext;
 import com.sublinks.sublinksapi.person.repositories.CaptchaRepository;
-import com.sublinks.sublinksapi.api.lemmy.v3.user.services.CaptchaService;
+import com.sublinks.sublinksapi.person.services.CaptchaService;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
 
 @Component
 @EnableScheduling
@@ -19,24 +20,29 @@ public class CaptchaScheduler {
 
   private final CaptchaService captchaService;
   private final CaptchaRepository captchaRepository;
-
+  private final LocalInstanceContext localInstanceContext;
 
 
   @Value("${sublinks.settings.captcha.max_captchas}")
   private final long maxCaptchas = 100;
 
   @Value("${sublinks.settings.captcha.rate}")
-  private final long rate = 15*60;
+  private final long rate = 15 * 60;
 
   @Value("${sublinks.settings.captcha.clearing_rate}")
-  private final long clearingRate = 15*60;
+  private final long clearingRate = 15 * 60;
 
   @Value("${sublinks.settings.captcha.clearing_older_than}")
-  private final long clearingCaptchaOlderThan = 15*60;
+  private final long clearingCaptchaOlderThan = 15 * 60;
 
 
-  @Scheduled(fixedRate=rate, timeUnit = TimeUnit.SECONDS)
+  @Scheduled(fixedRate = rate, timeUnit = TimeUnit.SECONDS)
   public void generateCachedCaptcha() {
+
+    if (localInstanceContext.instance().getInstanceConfig() == null
+        || !localInstanceContext.instance().getInstanceConfig().isCaptchaEnabled()) {
+      return;
+    }
 
     long quantity = captchaRepository.countAllByLockedFalse();
 
@@ -44,15 +50,16 @@ public class CaptchaScheduler {
       return;
     }
 
-    for (long i=quantity; i<100; i++) {
+    for (long i = quantity; i < 100; i++) {
       captchaService.createCaptcha();
     }
   }
 
-  @Scheduled(fixedRate=clearingRate, timeUnit = TimeUnit.SECONDS)
+  @Scheduled(fixedRate = clearingRate, timeUnit = TimeUnit.SECONDS)
   public void clearLockedCaptcha() {
-      captchaRepository.deleteAll(captchaRepository.findAllByLockedTrueAndUpdatedAtBefore(
-              new Date(System.currentTimeMillis() - clearingCaptchaOlderThan*1000)
-      ));
+
+    captchaRepository.deleteAll(captchaRepository.findAllByLockedTrueAndUpdatedAtBefore(
+        new Date(System.currentTimeMillis() - clearingCaptchaOlderThan * 1000)
+    ));
   }
 }


### PR DESCRIPTION
This update refactors the Captcha service and introduces an added feature to adjust complexity levels. The noise producers and captcha renderers have been revised to provide different levels of difficulty. The configuration updates will permit setting captcha difficulty - impacting the generation process. Significant enhancements have also been made to the 'captcha' table in the database to ensure efficient functioning and error handling during the registration process. Additionally, an unmapped target policy has been included to prevent unexpected mapping processes.