### PR TITLE
Non-alphanumeric characters are not removed when converting a string to a slug #173

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/utils/SlugUtil.java
+++ b/src/main/java/com/sublinks/sublinksapi/utils/SlugUtil.java
@@ -20,7 +20,7 @@ public class SlugUtil {
     return title
         .toLowerCase()
         .replace("\n", " ")
-        .replace("[^a-z\\d\\s]", " ")
+        .replaceAll("[^a-z\\d\\s]", " ")
         .replaceAll("\\s+", "_");
   }
 

--- a/src/test/java/com/sublinks/sublinksapi/utils/SlugUtilUnitTest.java
+++ b/src/test/java/com/sublinks/sublinksapi/utils/SlugUtilUnitTest.java
@@ -1,6 +1,5 @@
 package com.sublinks.sublinksapi.utils;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import java.util.regex.Pattern;
 
@@ -25,7 +24,6 @@ public class SlugUtilUnitTest {
   }
 
   @Test
-  @Disabled // Issue #173
   void givenStringWithNonAlphaNumericCharacters_whenStringToSlug_thenReturnStringAsSlug() {
 
     String titleString = "[])this(\\is}{*a&-string#%^";


### PR DESCRIPTION
Changed replace with replaceAll in SlugUtils. Enabled disabled test.