### PR TITLE
Add email functionality and templates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,12 @@ dependencies {
     implementation 'cn.apiclub.tool:simplecaptcha:1.2.2'
     implementation 'com.github.jai-imageio:jai-imageio-core:1.4.0'
 
+
+    implementation 'org.springframework.boot:spring-boot-starter-mail:3.2.2'
+    implementation 'org.apache.commons:commons-text:1.11.0'
+    implementation 'org.thymeleaf:thymeleaf:3.1.2.RELEASE'
+    implementation 'org.thymeleaf:thymeleaf-spring6:3.1.2.RELEASE'
+
     implementation "org.mapstruct:mapstruct:1.5.5.Final"
     compileOnly 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     compileOnly 'org.mapstruct:mapstruct:1.5.5.Final'

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/site/controllers/SiteController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/site/controllers/SiteController.java
@@ -141,6 +141,7 @@ public class SiteController extends AbstractLemmyApiController {
     config.defaultPostListingType(createSiteForm.default_post_listing_type());
     config.legalInformation(createSiteForm.legal_information());
     config.captchaDifficulty(createSiteForm.captcha_difficulty());
+    config.reportEmailAdmins(false);
 
     final InstanceConfig instanceConfig = config.build();
 
@@ -208,6 +209,7 @@ public class SiteController extends AbstractLemmyApiController {
     config.setDefaultTheme(editSiteForm.default_theme());
     config.setDefaultPostListingType(editSiteForm.default_post_listing_type());
     config.setLegalInformation(editSiteForm.legal_information());
+    config.setReportEmailAdmins(editSiteForm.application_email_admins());
 
     config.setRegistrationMode(editSiteForm.registration_mode());
     config.setRegistrationQuestion(editSiteForm.application_question());

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/site/models/EditSite.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/site/models/EditSite.java
@@ -25,6 +25,7 @@ public record EditSite(
     ListingType default_post_listing_type,
     String legal_information,
     Boolean application_email_admins,
+    Boolean reports_email_admins,
     Boolean hide_modlog_mod_names,
     Collection<String> discussion_languages,
     String slur_filter_regex,

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
@@ -153,7 +153,11 @@ public class UserAuthController extends AbstractLemmyApiController {
                 + "TODO");
         try {
           emailService.sendEmail(CreateEmailRequest.builder().to(List.of(person.getEmail()))
-              .subject("Verify your email").templateData(new Context(Locale.getDefault(), params))
+              .subject(emailService.getSubjects().get("verify_email").getAsString())
+              .body(emailService.formatTextEmailTemplate("verify_email",
+                  new Context(Locale.getDefault(), params)))
+              .htmlBody(emailService.formatEmailTemplate("verify_email",
+                  new Context(Locale.getDefault(), params)))
               .build());
           send_verification_email = true;
         } catch (Exception e) {

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
@@ -19,6 +19,7 @@ import com.sublinks.sublinksapi.api.lemmy.v3.user.models.UpdateTotpResponse;
 import com.sublinks.sublinksapi.api.lemmy.v3.user.models.VerifyEmailResponse;
 import com.sublinks.sublinksapi.authorization.enums.RolePermission;
 import com.sublinks.sublinksapi.authorization.services.RoleAuthorizingService;
+import com.sublinks.sublinksapi.email.enums.EmailTemplatesEnum;
 import com.sublinks.sublinksapi.email.models.CreateEmailRequest;
 import com.sublinks.sublinksapi.email.services.EmailService;
 import com.sublinks.sublinksapi.instance.dto.InstanceConfig;
@@ -153,11 +154,12 @@ public class UserAuthController extends AbstractLemmyApiController {
             localInstanceContext.instance().getDomain() + "/api/v3/user/verify_email?token="
                 + "TODO");
         try {
+          final String template_name = EmailTemplatesEnum.VERIFY_EMAIL.toString();
           emailService.sendEmail(CreateEmailRequest.builder().to(List.of(person.getEmail()))
-              .subject(emailService.getSubjects().get("verify_email").getAsString())
-              .body(emailService.formatTextEmailTemplate("verify_email",
+              .subject(emailService.getSubjects().get(template_name).getAsString())
+              .body(emailService.formatTextEmailTemplate(template_name,
                   new Context(Locale.getDefault(), params)))
-              .htmlBody(emailService.formatEmailTemplate("verify_email",
+              .htmlBody(emailService.formatEmailTemplate(template_name,
                   new Context(Locale.getDefault(), params)))
               .build());
           send_verification_email = true;
@@ -173,10 +175,11 @@ public class UserAuthController extends AbstractLemmyApiController {
       try {
         final Context context = new Context(Locale.getDefault(), properties);
 
+        final String template_name = EmailTemplatesEnum.REGISTRATION_SUCCESS.toString();
         emailService.sendEmail(CreateEmailRequest.builder().to(List.of(person.getEmail()))
-            .subject(emailService.getSubjects().get("registration_success").getAsString())
-            .body(emailService.formatTextEmailTemplate("registration_success", context))
-            .htmlBody(emailService.formatEmailTemplate("registration_success", context))
+            .subject(emailService.getSubjects().get(template_name).getAsString())
+            .body(emailService.formatTextEmailTemplate(template_name, context))
+            .htmlBody(emailService.formatEmailTemplate(template_name, context))
             .build());
       } catch (Exception e) {
         // @todo log error?

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
@@ -17,9 +17,10 @@ import com.sublinks.sublinksapi.api.lemmy.v3.user.models.SuccessResponse;
 import com.sublinks.sublinksapi.api.lemmy.v3.user.models.UpdateTotp;
 import com.sublinks.sublinksapi.api.lemmy.v3.user.models.UpdateTotpResponse;
 import com.sublinks.sublinksapi.api.lemmy.v3.user.models.VerifyEmailResponse;
-import com.sublinks.sublinksapi.person.services.CaptchaService;
 import com.sublinks.sublinksapi.authorization.enums.RolePermission;
 import com.sublinks.sublinksapi.authorization.services.RoleAuthorizingService;
+import com.sublinks.sublinksapi.email.models.CreateEmailRequest;
+import com.sublinks.sublinksapi.email.services.EmailService;
 import com.sublinks.sublinksapi.instance.dto.InstanceConfig;
 import com.sublinks.sublinksapi.instance.models.LocalInstanceContext;
 import com.sublinks.sublinksapi.person.dto.Captcha;
@@ -27,6 +28,7 @@ import com.sublinks.sublinksapi.person.dto.Person;
 import com.sublinks.sublinksapi.person.dto.PersonRegistrationApplication;
 import com.sublinks.sublinksapi.person.enums.PersonRegistrationApplicationStatus;
 import com.sublinks.sublinksapi.person.repositories.PersonRepository;
+import com.sublinks.sublinksapi.person.services.CaptchaService;
 import com.sublinks.sublinksapi.person.services.PersonRegistrationApplicationService;
 import com.sublinks.sublinksapi.person.services.PersonService;
 import com.sublinks.sublinksapi.slurfilter.exceptions.SlurFilterBlockedException;
@@ -41,6 +43,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +59,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import org.thymeleaf.context.Context;
 
 @RestController
 @RequiredArgsConstructor
@@ -70,6 +76,7 @@ public class UserAuthController extends AbstractLemmyApiController {
   private final CaptchaService captchaService;
   private final RoleAuthorizingService roleAuthorizingService;
   private final ConversionService conversionService;
+  private final EmailService emailService;
 
   @Operation(summary = "Register a new user.")
   @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
@@ -83,8 +90,7 @@ public class UserAuthController extends AbstractLemmyApiController {
       @ApiResponse(responseCode = "400", description = "Captcha is incorrect.", content = {
           @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = LemmyException.class))}),
       @ApiResponse(responseCode = "400", description = "Person is blocked by slur filter.", content = {
-          @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ApiError.class))})
-  })
+          @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ApiError.class))})})
   @PostMapping("register")
   LoginResponse create(@Valid @RequestBody final Register registerForm) throws LemmyException {
 
@@ -114,6 +120,7 @@ public class UserAuthController extends AbstractLemmyApiController {
     }
 
     final Person person = personService.getDefaultNewUser(registerForm.username());
+    person.setEmail(registerForm.email());
     if (!Objects.equals(registerForm.password(), registerForm.password_verify())) {
       throw new RuntimeException("Passwords do not match");
       // @todo throw lemmy error code
@@ -121,18 +128,58 @@ public class UserAuthController extends AbstractLemmyApiController {
     personService.createPerson(person);
     String token = jwtUtil.generateToken(person);
 
-    if (instanceConfig != null
-        && instanceConfig.getRegistrationMode() == RegistrationMode.RequireApplication) {
-      personRegistrationApplicationService.createPersonRegistrationApplication(
-          PersonRegistrationApplication.builder()
-              .applicationStatus(PersonRegistrationApplicationStatus.pending).person(person)
-              .question(instanceConfig.getRegistrationQuestion()).answer(registerForm.answer())
+    boolean send_verification_email = false;
+
+    if (instanceConfig != null) {
+      if (instanceConfig.getRegistrationMode() == RegistrationMode.RequireApplication) {
+
+        personRegistrationApplicationService.createPersonRegistrationApplication(
+            PersonRegistrationApplication.builder()
+                .applicationStatus(PersonRegistrationApplicationStatus.pending).person(person)
+                .question(instanceConfig.getRegistrationQuestion()).answer(registerForm.answer())
+                .build());
+        token = "";
+      }
+
+      if (instanceConfig.isRequireEmailVerification()) {
+        if (person.getEmail() == null) {
+          throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "email_required");
+        }
+        Map<String, Object> params = emailService.getDefaultEmailParameters();
+
+        params.put("person", person);
+        params.put("verificationUrl",
+            localInstanceContext.instance().getDomain() + "/api/v3/user/verify_email?token="
+                + "TODO");
+        try {
+          emailService.sendEmail(CreateEmailRequest.builder().to(List.of(person.getEmail()))
+              .subject("Verify your email").templateData(new Context(Locale.getDefault(), params))
               .build());
-      token = "";
+          send_verification_email = true;
+        } catch (Exception e) {
+          throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+              "email_sending_failed");
+        }
+      }
+    } else {
+      Map<String, Object> properties = emailService.getDefaultEmailParameters();
+      properties.put("person", person);
+
+      try {
+        final Context context = new Context(Locale.getDefault(), properties);
+
+        emailService.sendEmail(CreateEmailRequest.builder().to(List.of(person.getEmail()))
+            .subject(emailService.getSubjects().get("registration_success").getAsString())
+            .body(emailService.formatTextEmailTemplate("registration_success", context))
+            .htmlBody(emailService.formatEmailTemplate("registration_success", context))
+            .build());
+      } catch (Exception e) {
+        // @todo log error?
+      }
     }
 
-    return LoginResponse.builder().jwt(token).registration_created(true).verify_email_sent(false)
-        .build();
+    return LoginResponse.builder().jwt(token).registration_created(true)
+        .verify_email_sent(send_verification_email).build();
   }
 
   @Operation(summary = "Fetch a Captcha.")
@@ -282,8 +329,7 @@ public class UserAuthController extends AbstractLemmyApiController {
 
     final Person person = getPersonOrThrowUnauthorized(principal);
 
-    UpdateTotpResponse.UpdateTotpResponseBuilder updateTotpResponseBuilder = UpdateTotpResponse
-        .builder();
+    UpdateTotpResponse.UpdateTotpResponseBuilder updateTotpResponseBuilder = UpdateTotpResponse.builder();
 
     if (updateTotpForm.enabled()) {
       if (person.getTotpSecret() == null) {
@@ -308,8 +354,7 @@ public class UserAuthController extends AbstractLemmyApiController {
     return updateTotpResponseBuilder.enabled(true).build();
   }
 
-  @Operation(summary =
-      "Validates your Token, throws an error if it is invalid.")
+  @Operation(summary = "Validates your Token, throws an error if it is invalid.")
   @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
       @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UpdateTotpResponse.class))})})
   @PostMapping("validate_auth")

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
@@ -142,6 +142,7 @@ public class UserAuthController extends AbstractLemmyApiController {
       }
 
       if (instanceConfig.isRequireEmailVerification()) {
+        // @todo: Implement email verification
         if (person.getEmail() == null) {
           throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "email_required");
         }

--- a/src/main/java/com/sublinks/sublinksapi/email/config/EmailConfig.java
+++ b/src/main/java/com/sublinks/sublinksapi/email/config/EmailConfig.java
@@ -1,0 +1,123 @@
+package com.sublinks.sublinksapi.email.config;
+
+import java.util.Properties;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+import org.thymeleaf.templateresolver.ITemplateResolver;
+
+@Configuration
+@Getter
+@NoArgsConstructor
+public class EmailConfig {
+
+  @Value("${sublinks.settings.email.enabled}")
+  private boolean enabled;
+
+  @Value("${sublinks.settings.email.sender}")
+  private String sender;
+
+  @Value("${sublinks.settings.email.sender_name}")
+  private String senderName;
+
+  @Value("${sublinks.settings.email.host}")
+  private String host;
+
+  @Value("${sublinks.settings.email.port}")
+  private int port;
+
+  @Value("${sublinks.settings.email.smtp.username}")
+  private String smtpUser;
+
+  @Value("${sublinks.settings.email.smtp.password}")
+  private String smtpPassword;
+
+  @Value("${sublinks.settings.email.tls}")
+  private boolean smtpTlsEnable;
+
+  @Value("${sublinks.settings.email.ssl}")
+  private boolean smtpSslEnable;
+
+  @Value("${sublinks.settings.email.trusted}")
+  private String smtpSslTrust;
+
+  @Value("${sublinks.settings.email.starttls}")
+  private boolean smtpStartTls;
+
+  @Value("${sublinks.settings.email.starttls.required}")
+  private boolean smtpStartTlsRequired;
+
+  @Value("${sublinks.settings.email.debug}")
+  private boolean debug;
+
+
+  @Bean
+  public JavaMailSender getJavaMailSender() {
+
+    JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+    mailSender.setHost(host);
+    mailSender.setPort(port);
+
+    mailSender.setUsername(smtpUser);
+    mailSender.setPassword(smtpPassword);
+
+    Properties props = mailSender.getJavaMailProperties();
+    props.put("mail.transport.protocol", "smtp");
+    props.put("mail.smtp.auth", "true");
+    props.put("mail.smtp.starttls.enable", smtpStartTls);
+    props.put("mail.smtp.starttls.required", smtpStartTlsRequired);
+    props.put("mail.smtp.ssl.enable", smtpSslEnable);
+    props.put("mail.smtp.ssl.trust", smtpSslTrust);
+    props.put("mail.debug", debug);
+
+    return mailSender;
+  }
+
+  @Primary
+  @Bean
+  public ITemplateResolver templateResolver() {
+
+    ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
+    templateResolver.setPrefix("email-templates/");
+    templateResolver.setSuffix(".html");
+    templateResolver.setTemplateMode("HTML");
+    templateResolver.setCharacterEncoding("UTF-8");
+    return templateResolver;
+  }
+
+  @Primary
+  @Bean
+  public SpringTemplateEngine templateEngine(ITemplateResolver templateResolver) {
+
+    SpringTemplateEngine templateEngine = new SpringTemplateEngine();
+    templateEngine.setTemplateResolver(templateResolver);
+    return templateEngine;
+  }
+
+  @Bean(name = "textTemplateResolver", autowireCandidate = false)
+  public ITemplateResolver textTemplateResolver() {
+
+    ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
+    templateResolver.setPrefix("email-templates/");
+    templateResolver.setSuffix(".txt");
+    templateResolver.setTemplateMode("TEXT");
+    templateResolver.setCharacterEncoding("UTF-8");
+    return templateResolver;
+  }
+
+  @Bean(name = "textTemplateEngine", autowireCandidate = false)
+  public SpringTemplateEngine textTemplateEngine(ITemplateResolver textTemplateResolver) {
+
+    SpringTemplateEngine templateEngine = new SpringTemplateEngine();
+    templateEngine.setTemplateResolver(textTemplateResolver);
+    return templateEngine;
+  }
+}

--- a/src/main/java/com/sublinks/sublinksapi/email/enums/EmailTemplatesEnum.java
+++ b/src/main/java/com/sublinks/sublinksapi/email/enums/EmailTemplatesEnum.java
@@ -1,0 +1,27 @@
+package com.sublinks.sublinksapi.email.enums;
+
+public enum EmailTemplatesEnum {
+  DM_MESSAGE("dm_message"),
+  PASSWORD_RESET("password_reset"),
+  NEW_REGISTRATION_APPLICATION("new_registration_application"),
+  NEW_REPORT("new_report"),
+  REGISTRATION_APPROVED("registration_approved"),
+  REGISTRATION_SUCCESS("registration_success"),
+  VERIFY_EMAIL("verify_email"),
+  ;
+
+
+  private final String template_name;
+
+  EmailTemplatesEnum(String template_name) {
+
+    this.template_name = template_name;
+  }
+
+
+  @Override
+  public String toString() {
+
+    return template_name;
+  }
+}

--- a/src/main/java/com/sublinks/sublinksapi/email/events/EmailCreatedEvent.java
+++ b/src/main/java/com/sublinks/sublinksapi/email/events/EmailCreatedEvent.java
@@ -1,0 +1,17 @@
+package com.sublinks.sublinksapi.email.events;
+
+import com.sublinks.sublinksapi.email.models.CreateEmailEvent;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class EmailCreatedEvent extends ApplicationEvent {
+
+  private final CreateEmailEvent event;
+
+  public EmailCreatedEvent(final Object source, final CreateEmailEvent event) {
+
+    super(source);
+    this.event = event;
+  }
+}

--- a/src/main/java/com/sublinks/sublinksapi/email/events/EmailCreatedPublisher.java
+++ b/src/main/java/com/sublinks/sublinksapi/email/events/EmailCreatedPublisher.java
@@ -1,0 +1,19 @@
+package com.sublinks.sublinksapi.email.events;
+
+import com.sublinks.sublinksapi.email.models.CreateEmailEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailCreatedPublisher {
+
+  private final ApplicationEventPublisher applicationEventPublisher;
+
+  public void publish(final CreateEmailEvent event) {
+
+    final EmailCreatedEvent commentCreatedEvent = new EmailCreatedEvent(this, event);
+    applicationEventPublisher.publishEvent(commentCreatedEvent);
+  }
+}

--- a/src/main/java/com/sublinks/sublinksapi/email/listeners/CommentReportCreatedListener.java
+++ b/src/main/java/com/sublinks/sublinksapi/email/listeners/CommentReportCreatedListener.java
@@ -1,0 +1,30 @@
+package com.sublinks.sublinksapi.email.listeners;
+
+import com.sublinks.sublinksapi.comment.dto.Comment;
+import com.sublinks.sublinksapi.comment.dto.CommentReply;
+import com.sublinks.sublinksapi.comment.events.CommentCreatedEvent;
+import com.sublinks.sublinksapi.comment.events.CommentReportCreatedEvent;
+import com.sublinks.sublinksapi.comment.services.CommentReplyService;
+import com.sublinks.sublinksapi.comment.services.CommentService;
+import java.util.Optional;
+import com.sublinks.sublinksapi.instance.models.LocalInstanceContext;
+import com.sublinks.sublinksapi.person.services.PersonService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class CommentReportCreatedListener implements ApplicationListener<CommentReportCreatedEvent> {
+
+  private final LocalInstanceContext localInstanceContext;
+  private final PersonService personService;
+
+
+  @Override
+  @Transactional
+  public void onApplicationEvent(CommentReportCreatedEvent event) {
+    // @todo: implement on report created email on report created (post,comment,dm)
+  }
+}

--- a/src/main/java/com/sublinks/sublinksapi/email/listeners/RegistrationCreatedListener.java
+++ b/src/main/java/com/sublinks/sublinksapi/email/listeners/RegistrationCreatedListener.java
@@ -1,5 +1,6 @@
 package com.sublinks.sublinksapi.email.listeners;
 
+import com.sublinks.sublinksapi.email.enums.EmailTemplatesEnum;
 import com.sublinks.sublinksapi.email.models.CreateEmailRequest;
 import com.sublinks.sublinksapi.email.services.EmailService;
 import com.sublinks.sublinksapi.instance.models.LocalInstanceContext;
@@ -23,7 +24,8 @@ public class RegistrationCreatedListener implements
 
   @Override
   public void onApplicationEvent(PersonRegistrationApplicationCreatedEvent event) {
-    if(localInstanceContext.instance().getInstanceConfig() != null
+
+    if (localInstanceContext.instance().getInstanceConfig() != null
         && !localInstanceContext.instance().getInstanceConfig().isApplicationEmailAdmins()) {
       return;
     }
@@ -36,10 +38,11 @@ public class RegistrationCreatedListener implements
     Context context = new Context(Locale.getDefault(), properties);
 
     try {
+      final String template_name = EmailTemplatesEnum.NEW_REGISTRATION_APPLICATION.toString();
       emailService.sendEmail(CreateEmailRequest.builder().to(List.of(person.getEmail()))
-          .subject(emailService.getSubjects().get("new_registration_application").getAsString())
-          .body(emailService.formatTextEmailTemplate("new_registration_application", context))
-          .htmlBody(emailService.formatEmailTemplate("new_registration_application", context))
+          .subject(emailService.getSubjects().get(template_name).getAsString())
+          .body(emailService.formatTextEmailTemplate(template_name, context))
+          .htmlBody(emailService.formatEmailTemplate(template_name, context))
           .build());
     } catch (Exception e) {
       // @todo: log error

--- a/src/main/java/com/sublinks/sublinksapi/email/listeners/RegistrationCreatedListener.java
+++ b/src/main/java/com/sublinks/sublinksapi/email/listeners/RegistrationCreatedListener.java
@@ -23,7 +23,10 @@ public class RegistrationCreatedListener implements
 
   @Override
   public void onApplicationEvent(PersonRegistrationApplicationCreatedEvent event) {
-
+    if(localInstanceContext.instance().getInstanceConfig() != null
+        && !localInstanceContext.instance().getInstanceConfig().isApplicationEmailAdmins()) {
+      return;
+    }
     final Person person = event.getPersonRegistrationApplication().getPerson();
 
     Map<String, Object> properties = emailService.getDefaultEmailParameters();

--- a/src/main/java/com/sublinks/sublinksapi/email/listeners/RegistrationCreatedListener.java
+++ b/src/main/java/com/sublinks/sublinksapi/email/listeners/RegistrationCreatedListener.java
@@ -1,0 +1,46 @@
+package com.sublinks.sublinksapi.email.listeners;
+
+import com.sublinks.sublinksapi.email.models.CreateEmailRequest;
+import com.sublinks.sublinksapi.email.services.EmailService;
+import com.sublinks.sublinksapi.instance.models.LocalInstanceContext;
+import com.sublinks.sublinksapi.person.dto.Person;
+import com.sublinks.sublinksapi.person.events.PersonRegistrationApplicationCreatedEvent;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+
+@Component
+@AllArgsConstructor
+public class RegistrationCreatedListener implements
+    ApplicationListener<PersonRegistrationApplicationCreatedEvent> {
+
+  private final LocalInstanceContext localInstanceContext;
+  private final EmailService emailService;
+
+  @Override
+  public void onApplicationEvent(PersonRegistrationApplicationCreatedEvent event) {
+
+    final Person person = event.getPersonRegistrationApplication().getPerson();
+
+    Map<String, Object> properties = emailService.getDefaultEmailParameters();
+    properties.put("person", person);
+    properties.putAll(emailService.getDefaultPersonEmailParameters(person));
+
+    Context context = new Context(Locale.getDefault(), properties);
+
+    try {
+      emailService.sendEmail(CreateEmailRequest.builder().to(List.of(person.getEmail()))
+          .subject(emailService.getSubjects().get("new_registration_application").getAsString())
+          .body(emailService.formatTextEmailTemplate("new_registration_application", context))
+          .htmlBody(emailService.formatEmailTemplate("new_registration_application", context))
+          .build());
+    } catch (Exception e) {
+      // @todo: log error
+    }
+  }
+
+}

--- a/src/main/java/com/sublinks/sublinksapi/email/models/CreateEmailEvent.java
+++ b/src/main/java/com/sublinks/sublinksapi/email/models/CreateEmailEvent.java
@@ -1,0 +1,11 @@
+package com.sublinks.sublinksapi.email.models;
+
+import lombok.Builder;
+
+@Builder
+public record CreateEmailEvent(
+    CreateEmailRequest createEmailRequest
+) {
+
+
+}

--- a/src/main/java/com/sublinks/sublinksapi/email/models/CreateEmailRequest.java
+++ b/src/main/java/com/sublinks/sublinksapi/email/models/CreateEmailRequest.java
@@ -1,0 +1,24 @@
+package com.sublinks.sublinksapi.email.models;
+
+
+import jakarta.mail.internet.MimeBodyPart;
+import lombok.Builder;
+import org.springframework.lang.NonNull;
+import org.thymeleaf.context.Context;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+@Builder
+public record CreateEmailRequest(
+    @NonNull
+    List<String> to,
+    List<String> cc,
+    @NonNull
+    String subject,
+    String htmlBody,
+    String body,
+    File[] attachments
+) {
+
+}

--- a/src/main/java/com/sublinks/sublinksapi/email/services/EmailService.java
+++ b/src/main/java/com/sublinks/sublinksapi/email/services/EmailService.java
@@ -1,0 +1,126 @@
+package com.sublinks.sublinksapi.email.services;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.sublinks.sublinksapi.email.config.EmailConfig;
+import com.sublinks.sublinksapi.email.models.CreateEmailRequest;
+import com.sublinks.sublinksapi.instance.models.LocalInstanceContext;
+import com.sublinks.sublinksapi.person.dto.Person;
+import com.sublinks.sublinksapi.utils.FileUtils;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.context.IContext;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Component
+@RequiredArgsConstructor
+public class EmailService {
+
+  private final EmailConfig emailConfig;
+  private final LocalInstanceContext localInstanceContext;
+  private final SpringTemplateEngine templateEngine;
+  private final SpringTemplateEngine textTemplateEngine;
+
+  private JavaMailSender getMailSender() {
+
+    return emailConfig.getJavaMailSender();
+  }
+
+  public void sendEmail(@NonNull CreateEmailRequest request)
+      throws MessagingException, UnsupportedEncodingException {
+
+    if (!emailConfig.isEnabled()) {
+      return;
+    }
+    if (request.to().isEmpty()) {
+      return;
+    }
+    JavaMailSender sender = getMailSender();
+
+    final MimeMessage msg = sender.createMimeMessage();
+
+    MimeMessageHelper helper = new MimeMessageHelper(msg, true);
+
+    helper.setFrom(emailConfig.getSender(), emailConfig.getSenderName());
+    helper.setTo(request.to().toArray(new String[0]));
+    helper.setSubject(request.subject());
+    helper.setText(request.body(), request.htmlBody());
+
+    if (request.attachments() != null) {
+      for (File file : request.attachments()) {
+        helper.addAttachment(file.getName(), file);
+      }
+    }
+
+    getMailSender().send(msg);
+  }
+
+  public Map<String, Object> getDefaultEmailParameters() {
+
+    Map<String, Object> params = new HashMap<>();
+
+    params.put("instance", localInstanceContext.instance());
+    params.put("instanceName", localInstanceContext.instance().getName());
+    params.put("instanceDomain", localInstanceContext.instance().getDomain());
+    params.put("instanceIconUrl", localInstanceContext.instance().getIconUrl());
+    params.put("instanceBannerUrl", localInstanceContext.instance().getBannerUrl());
+    params.put("instanceDescription", localInstanceContext.instance().getDescription());
+    params.put("instanceSidebar", localInstanceContext.instance().getSidebar());
+    return params;
+  }
+
+  public String formatEmailTemplate(final String template, @Nullable IContext params) {
+
+    if (params == null) {
+      params = new Context(Locale.getDefault(), getDefaultEmailParameters());
+    }
+
+    return templateEngine.process(template, params);
+  }
+
+  public String formatTextEmailTemplate(final String template, @Nullable IContext params) {
+
+    if (params == null) {
+      params = new Context(Locale.getDefault(), getDefaultEmailParameters());
+    }
+
+    return textTemplateEngine.process(template, params);
+  }
+
+  public JsonObject getSubjects() throws IOException {
+
+    String subjectsJson = FileUtils.readFromInputStream(
+        new FileInputStream("email-templates/subjects.json"));
+
+    return new Gson().fromJson(subjectsJson, JsonObject.class);
+  }
+
+  public Map<String, Object> getDefaultPersonEmailParameters(final Person person) {
+
+    Map<String, Object> params = getDefaultEmailParameters();
+
+    params.put("person", person);
+    params.put("userName", person.getName());
+    params.put("userId", person.getId());
+    params.put("userEmail", person.getEmail());
+    params.put("userAvatar", person.getAvatarImageUrl());
+    params.put("userBanner", person.getBannerImageUrl());
+    params.put("userBio", person.getBiography());
+
+    return params;
+  }
+}

--- a/src/main/java/com/sublinks/sublinksapi/email/services/EmailService.java
+++ b/src/main/java/com/sublinks/sublinksapi/email/services/EmailService.java
@@ -3,6 +3,9 @@ package com.sublinks.sublinksapi.email.services;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.sublinks.sublinksapi.email.config.EmailConfig;
+import com.sublinks.sublinksapi.email.events.EmailCreatedEvent;
+import com.sublinks.sublinksapi.email.events.EmailCreatedPublisher;
+import com.sublinks.sublinksapi.email.models.CreateEmailEvent;
 import com.sublinks.sublinksapi.email.models.CreateEmailRequest;
 import com.sublinks.sublinksapi.instance.models.LocalInstanceContext;
 import com.sublinks.sublinksapi.person.dto.Person;
@@ -34,6 +37,7 @@ public class EmailService {
   private final LocalInstanceContext localInstanceContext;
   private final SpringTemplateEngine templateEngine;
   private final SpringTemplateEngine textTemplateEngine;
+  private final EmailCreatedPublisher emailCreatedPublisher;
 
   private JavaMailSender getMailSender() {
 
@@ -67,6 +71,9 @@ public class EmailService {
     }
 
     getMailSender().send(msg);
+
+    emailCreatedPublisher.publish(CreateEmailEvent.builder().createEmailRequest(request).build());
+
   }
 
   public Map<String, Object> getDefaultEmailParameters() {

--- a/src/main/java/com/sublinks/sublinksapi/instance/dto/InstanceConfig.java
+++ b/src/main/java/com/sublinks/sublinksapi/instance/dto/InstanceConfig.java
@@ -69,6 +69,9 @@ public class InstanceConfig {
   @Column(name = "application_email_admins")
   private boolean applicationEmailAdmins;
 
+  @Column(name = "report_email_admins")
+  private boolean reportEmailAdmins;
+
   @Column(name = "hide_modlog_mod_names")
   private boolean hideModlogModNames;
 

--- a/src/main/java/com/sublinks/sublinksapi/person/services/PersonService.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/services/PersonService.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -196,6 +195,10 @@ public class PersonService {
     person.setPublicKey(keys.publicKey());
     person.setPrivateKey(keys.privateKey());
     person.setLocal(true);
+    person.setEmail(person.getEmail());
+    // @todo: add email verification and send verification email on registration
+    person.setEmailVerified(localInstanceContext.instance().getInstanceConfig() == null
+        || !localInstanceContext.instance().getInstanceConfig().isRequireEmailVerification());
 
     boolean isInitialAdmin = localInstanceContext.instance().getDomain().isEmpty();
     if (isInitialAdmin) {

--- a/src/main/java/com/sublinks/sublinksapi/utils/FileUtils.java
+++ b/src/main/java/com/sublinks/sublinksapi/utils/FileUtils.java
@@ -1,0 +1,23 @@
+package com.sublinks.sublinksapi.utils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+public class FileUtils {
+
+  public static String readFromInputStream(InputStream inputStream)
+      throws IOException {
+
+    StringBuilder resultStringBuilder = new StringBuilder();
+    try (BufferedReader br
+        = new BufferedReader(new InputStreamReader(inputStream))) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        resultStringBuilder.append(line).append("\n");
+      }
+    }
+    return resultStringBuilder.toString();
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,7 +36,19 @@ sublinks.settings.captcha.clearing_rate=900
 sublinks.settings.captcha.clearing_older_than=900
 sublinks.settings.captcha.max_captchas=900
 
-
+sublinks.settings.email.enabled=${SUBLINKS_MAIL_ENABLED:true}
+sublinks.settings.email.host=${SUBLINKS_MAIL_HOST:}
+sublinks.settings.email.port=${SUBLINKS_MAIL_PORT:587}
+sublinks.settings.email.smtp.username=${SUBLINKS_MAIL_USERNAME:}
+sublinks.settings.email.smtp.password=${SUBLINKS_MAIL_PASSWORD:}
+sublinks.settings.email.sender=${SUBLINKS_MAIL_SENDER:}
+sublinks.settings.email.sender_name=${SUBLINKS_MAIL_SENDER_NAME:Sublinks}
+sublinks.settings.email.tls=${SUBLINKS_MAIL_TLS:true}
+sublinks.settings.email.ssl=${SUBLINKS_MAIL_SSL:false}
+sublinks.settings.email.trusted=${SUBLINKS_MAIL_TRUSTED:}
+sublinks.settings.email.starttls=${SUBLINKS_MAIL_STARTTLS:true}
+sublinks.settings.email.starttls.required=${SUBLINKS_MAIL_STARTTLS_REQUIRED:false}
+sublinks.settings.email.debug=${SUBLINKS_MAIL_DEBUG:false}
 
 sublinks.settings.private_instance=true
 sublinks.pictrs.url=${SUBLINKS_PICTRS_URL}

--- a/src/main/resources/db/migration/V20231003__Create_initial_entity_tables.sql
+++ b/src/main/resources/db/migration/V20231003__Create_initial_entity_tables.sql
@@ -627,6 +627,7 @@ CREATE TABLE `instance_configs`
   `enable_nsfw`                   TINYINT                                              NULL,
   `community_creation_admin_only` TINYINT                                              NULL,
   `application_email_admins`      TINYINT                                              NULL,
+  `report_email_admins`           TINYINT                                              NULL,
   `hide_modlog_mod_names`         TINYINT                                              NULL,
   `federation_enabled`            TINYINT                                              NULL,
   `captcha_enabled`               TINYINT                                              NULL,

--- a/src/main/resources/email-templates/dm_message.html
+++ b/src/main/resources/email-templates/dm_message.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <title th:text="${instanceName}"></title>
+</head>
+<body>
+<p th:text="${instanceName}"></p>
+<p th:text="${instanceDomain}"></p>
+<p th:text="${userName}"></p>
+</body>
+</html>

--- a/src/main/resources/email-templates/dm_message.txt
+++ b/src/main/resources/email-templates/dm_message.txt
@@ -1,0 +1,1 @@
+Your Registration on {instanceName}

--- a/src/main/resources/email-templates/headers.json
+++ b/src/main/resources/email-templates/headers.json
@@ -1,0 +1,9 @@
+{
+  "dm_message": "You received a new message!",
+  "password_reset": "Your password reset url!",
+  "registration_approved": "Your registration has been approved!",
+  "verification_email": "Your verification email!",
+  "registration_success": "Your registration was successful!",
+  "new_registation_application": "There is a new registration application!",
+  "new_report": "There is a new report!"
+}

--- a/src/main/resources/email-templates/new_registration_application.html
+++ b/src/main/resources/email-templates/new_registration_application.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <title th:text="${instanceName}"></title>
+</head>
+<body>
+<p th:text="${instanceName}"></p>
+<p th:text="${instanceDomain}"></p>
+<p th:text="${userName}"></p>
+</body>
+</html>

--- a/src/main/resources/email-templates/new_registration_application.txt
+++ b/src/main/resources/email-templates/new_registration_application.txt
@@ -1,0 +1,3 @@
+Hi ${username},
+
+Your Registration on ${instanceName} was successful!

--- a/src/main/resources/email-templates/new_report.html
+++ b/src/main/resources/email-templates/new_report.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <title th:text="${instanceName}"></title>
+</head>
+<body>
+<p th:text="${instanceName}"></p>
+<p th:text="${instanceDomain}"></p>
+<p th:text="${userName}"></p>
+</body>
+</html>

--- a/src/main/resources/email-templates/new_report.txt
+++ b/src/main/resources/email-templates/new_report.txt
@@ -1,0 +1,3 @@
+Hi ${username},
+
+Your Registration on ${instanceName} was successful!

--- a/src/main/resources/email-templates/password_reset.html
+++ b/src/main/resources/email-templates/password_reset.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <title th:text="${instanceName}"></title>
+</head>
+<body>
+<p th:text="${instanceName}"></p>
+<p th:text="${instanceDomain}"></p>
+<p th:text="${userName}"></p>
+</body>
+</html>

--- a/src/main/resources/email-templates/password_reset.txt
+++ b/src/main/resources/email-templates/password_reset.txt
@@ -1,0 +1,1 @@
+Your Registration on {instanceName}

--- a/src/main/resources/email-templates/registration_approved.html
+++ b/src/main/resources/email-templates/registration_approved.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <title th:text="${instanceName}"></title>
+</head>
+<body>
+<p th:text="${instanceName}"></p>
+<p th:text="${instanceDomain}"></p>
+<p th:text="${userName}"></p>
+</body>
+</html>

--- a/src/main/resources/email-templates/registration_approved.txt
+++ b/src/main/resources/email-templates/registration_approved.txt
@@ -1,0 +1,3 @@
+Hi ${username},
+
+Your Registration on ${instanceName} was approved!

--- a/src/main/resources/email-templates/registration_success.html
+++ b/src/main/resources/email-templates/registration_success.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <title th:text="${instanceName}"></title>
+</head>
+<body>
+<p th:text="${instanceName}"></p>
+<p th:text="${instanceDomain}"></p>
+<p th:text="${userName}"></p>
+</body>
+</html>

--- a/src/main/resources/email-templates/registration_success.txt
+++ b/src/main/resources/email-templates/registration_success.txt
@@ -1,0 +1,3 @@
+Hi ${username},
+
+Your Registration on ${instanceName} was successful!

--- a/src/main/resources/email-templates/verify_email.html
+++ b/src/main/resources/email-templates/verify_email.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <title th:text="${instanceName}"></title>
+</head>
+<body>
+<p th:text="${instanceName}"></p>
+<p th:text="${instanceDomain}"></p>
+<p th:text="${userName}"></p>
+</body>
+</html>

--- a/src/main/resources/email-templates/verify_email.txt
+++ b/src/main/resources/email-templates/verify_email.txt
@@ -1,0 +1,1 @@
+Your Registration on {instanceName}


### PR DESCRIPTION
This commit introduces an email functionality to the application. New email templates for various events (e.g., registration, password reset) were added. The necessary configurations were set up to allow sending emails and formatting the email templates. Relevant listeners and services were implemented to handle emailing logic when these events occur. Some related changes were also made in user registration logic.

closes #93 #94 