### PR TITLE
fix: return nulls instead of empty strings from urlutil

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/utils/UrlUtil.java
+++ b/src/main/java/com/sublinks/sublinksapi/utils/UrlUtil.java
@@ -45,7 +45,7 @@ public class UrlUtil {
   private String removeTrackingParameters(final String queryString) {
 
     if (queryString == null || queryString.isEmpty()) {
-      return "";
+      return null;
     }
     Pattern pattern = Pattern.compile("(\\w+)=?([^&]+)?");
     Matcher matcher = pattern.matcher(queryString);
@@ -58,7 +58,7 @@ public class UrlUtil {
       }
     }
     if (parameters.isEmpty()) {
-      return "";
+      return null;
     }
     return parameters.entrySet().stream()
         .map(e -> e.getKey() + "=" + e.getValue())

--- a/src/test/java/com/sublinks/sublinksapi/utils/UrlUtilUnitTests.java
+++ b/src/test/java/com/sublinks/sublinksapi/utils/UrlUtilUnitTests.java
@@ -40,7 +40,6 @@ public class UrlUtilUnitTests {
   }
 
   @Test
-  @Disabled // ? is added to the end of urls with no parameters
   void givenHttpUrlWithNoParameters_whenNormalizeUrl_thenReturnUnmodifiedUrl() {
 
     String normalizedUrl = urlUtil.normalizeUrl(httpUrl);
@@ -49,7 +48,6 @@ public class UrlUtilUnitTests {
   }
 
   @Test
-  @Disabled // ? is added to the end of urls with no parameters
   void givenHttpsUrlWithNoParameters_whenNormalizeUrl_thenReturnUnmodifiedUrl() {
 
     String normalizedUrl = urlUtil.normalizeUrl(httpsUrl);
@@ -58,7 +56,6 @@ public class UrlUtilUnitTests {
   }
 
   @Test
-  @Disabled // ? is added to the end of urls that have all their parameters removed
   void givenHttpUrlWithOnlyTrackingParameters_whenNormalizeUrl_thenReturnUrlWithNoParameters() {
 
     String urlWithOnlyTrackingParameters = httpUrl + trackingParameters;
@@ -70,7 +67,6 @@ public class UrlUtilUnitTests {
   }
 
   @Test
-  @Disabled // ? is added to the end of urls that have all their parameters removed
   void givenHttpsUrlWithOnlyTrackingParameters_whenNormalizeUrl_thenReturnUrlWithNoParameters() {
 
     String urlWithOnlyTrackingParameters = httpsUrl + trackingParameters;


### PR DESCRIPTION
closes #168, implements suggested fix and enables the tests that were failing before this change