### PR TITLE
Add user IP tracking feature

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/authentication/JwtFilter.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/authentication/JwtFilter.java
@@ -2,6 +2,7 @@ package com.sublinks.sublinksapi.api.lemmy.v3.authentication;
 
 import com.sublinks.sublinksapi.person.dto.Person;
 import com.sublinks.sublinksapi.person.repositories.PersonRepository;
+import com.sublinks.sublinksapi.person.services.UserDataService;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -11,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -19,10 +21,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
 @RequiredArgsConstructor
+@Order(1)
 public class JwtFilter extends OncePerRequestFilter {
 
   private final JwtUtil jwtUtil;
   private final PersonRepository personRepository;
+  private final UserDataService userDataService;
 
   @Override
   protected void doFilterInternal(
@@ -65,6 +69,7 @@ public class JwtFilter extends OncePerRequestFilter {
       }
 
       if (jwtUtil.validateToken(token, person.get())) {
+        userDataService.checkAndAddIpRelation(person.get(), request.getRemoteAddr());
         final JwtPerson authenticationToken = new JwtPerson(person.get(),
             person.get().getAuthorities());
         authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/authentication/JwtFilter.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/authentication/JwtFilter.java
@@ -56,7 +56,7 @@ public class JwtFilter extends OncePerRequestFilter {
         } else {
           token = authorizingToken;
         }
-          userName = jwtUtil.extractUsername(token);
+        userName = jwtUtil.extractUsername(token);
       }
     } catch (ExpiredJwtException ex) {
       response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
@@ -69,7 +69,8 @@ public class JwtFilter extends OncePerRequestFilter {
       }
 
       if (jwtUtil.validateToken(token, person.get())) {
-        userDataService.checkAndAddIpRelation(person.get(), request.getRemoteAddr());
+        userDataService.checkAndAddIpRelation(person.get(), request.getRemoteAddr(),
+            request.getHeader("User-Agent"));
         final JwtPerson authenticationToken = new JwtPerson(person.get(),
             person.get().getAuthorities());
         authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));

--- a/src/main/java/com/sublinks/sublinksapi/person/config/CaptchaConfiguration.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/config/CaptchaConfiguration.java
@@ -9,14 +9,14 @@ import org.springframework.context.annotation.Configuration;
 public class CaptchaConfiguration {
 
   @Value("${sublinks.settings.captcha.max_captchas}")
-  private final long maxCaptchas = 100;
+  private long maxCaptchas;
 
   @Value("${sublinks.settings.captcha.rate}")
-  private final long rate = 15 * 60;
+  private long rate;
 
   @Value("${sublinks.settings.captcha.clearing_rate}")
-  private final long clearingRate = 15 * 60;
+  private long clearingRate;
 
   @Value("${sublinks.settings.captcha.clearing_older_than}")
-  private final long clearingCaptchaOlderThan = 15 * 60;
+  private long clearingCaptchaOlderThan;
 }

--- a/src/main/java/com/sublinks/sublinksapi/person/config/UserDataConfig.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/config/UserDataConfig.java
@@ -1,0 +1,14 @@
+package com.sublinks.sublinksapi.person.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class UserDataConfig {
+
+  @Value("${sublinks.save_user_ips}")
+  private boolean saveUserIps;
+}

--- a/src/main/java/com/sublinks/sublinksapi/person/config/UserDataConfig.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/config/UserDataConfig.java
@@ -11,4 +11,10 @@ public class UserDataConfig {
 
   @Value("${sublinks.save_user_ips}")
   private boolean saveUserIps;
+
+  @Value("${sublinks.settings.userdata.clear_rate}")
+  private long clearRate;
+
+  @Value("${sublinks.settings.userdata.clear_older_than}")
+  private long clearOlderThan;
 }

--- a/src/main/java/com/sublinks/sublinksapi/person/dto/Person.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/dto/Person.java
@@ -75,6 +75,9 @@ public class Person implements UserDetails, Principal {
   @OneToOne(mappedBy = "person", cascade = CascadeType.ALL)
   private LinkPersonInstance linkPersonInstance;
 
+  @OneToMany(mappedBy = "person")
+  private List<UserData> userData;
+
   @OneToMany
   @PrimaryKeyJoinColumn
   private List<Comment> comments;

--- a/src/main/java/com/sublinks/sublinksapi/person/dto/UserData.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/dto/UserData.java
@@ -32,7 +32,14 @@ public class UserData {
   @Column(nullable = false, name = "ip_address")
   private String ipAddress;
 
+  @Column(nullable = true, name = "user_agent")
+  private String userAgent;
+
   @CreationTimestamp
   @Column(updatable = false, nullable = false, name = "created_at")
   private Date createdAt;
+
+  @UpdateTimestamp
+  @Column(updatable = true, nullable = false, name = "last_used_at")
+  private Date lastUsedAt;
 }

--- a/src/main/java/com/sublinks/sublinksapi/person/dto/UserData.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/dto/UserData.java
@@ -1,7 +1,18 @@
 package com.sublinks.sublinksapi.person.dto;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import java.util.Date;

--- a/src/main/java/com/sublinks/sublinksapi/person/dto/UserData.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/dto/UserData.java
@@ -1,0 +1,38 @@
+package com.sublinks.sublinksapi.person.dto;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.util.Date;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "user_data")
+public class UserData {
+
+  /**
+   * Relationships.
+   */
+  @ManyToOne
+  @JoinColumn(name = "person_id")
+  private Person person;
+
+  /**
+   * Attributes.
+   */
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, name = "ip_address")
+  private String ipAddress;
+
+  @CreationTimestamp
+  @Column(updatable = false, nullable = false, name = "created_at")
+  private Date createdAt;
+}

--- a/src/main/java/com/sublinks/sublinksapi/person/events/UserDataCreatedEvent.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/events/UserDataCreatedEvent.java
@@ -1,0 +1,18 @@
+package com.sublinks.sublinksapi.person.events;
+
+import com.sublinks.sublinksapi.person.dto.Person;
+import com.sublinks.sublinksapi.person.dto.UserData;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class UserDataCreatedEvent extends ApplicationEvent {
+
+  private final UserData userData;
+
+  public UserDataCreatedEvent(Object source, UserData userData) {
+
+    super(source);
+    this.userData = userData;
+  }
+}

--- a/src/main/java/com/sublinks/sublinksapi/person/events/UserDataCreatedPublisher.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/events/UserDataCreatedPublisher.java
@@ -1,0 +1,26 @@
+package com.sublinks.sublinksapi.person.events;
+
+import com.sublinks.sublinksapi.person.dto.LinkPersonCommunity;
+import com.sublinks.sublinksapi.person.dto.UserData;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserDataCreatedPublisher {
+
+  private final ApplicationEventPublisher applicationEventPublisher;
+
+  public UserDataCreatedPublisher(
+      final ApplicationEventPublisher applicationEventPublisher
+  ) {
+
+    this.applicationEventPublisher = applicationEventPublisher;
+  }
+
+  public void publish(final UserData userData) {
+
+    UserDataCreatedEvent userDataCreatedEvent = new UserDataCreatedEvent(
+        this, userData);
+    applicationEventPublisher.publishEvent(userDataCreatedEvent);
+  }
+}

--- a/src/main/java/com/sublinks/sublinksapi/person/events/UserDataDeletedEvent.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/events/UserDataDeletedEvent.java
@@ -1,0 +1,17 @@
+package com.sublinks.sublinksapi.person.events;
+
+import com.sublinks.sublinksapi.person.dto.UserData;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class UserDataDeletedEvent extends ApplicationEvent {
+
+  private final UserData userData;
+
+  public UserDataDeletedEvent(Object source, UserData userData) {
+
+    super(source);
+    this.userData = userData;
+  }
+}

--- a/src/main/java/com/sublinks/sublinksapi/person/events/UserDataDeletedPublisher.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/events/UserDataDeletedPublisher.java
@@ -1,0 +1,25 @@
+package com.sublinks.sublinksapi.person.events;
+
+import com.sublinks.sublinksapi.person.dto.UserData;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserDataDeletedPublisher {
+
+  private final ApplicationEventPublisher applicationEventPublisher;
+
+  public UserDataDeletedPublisher(
+      final ApplicationEventPublisher applicationEventPublisher
+  ) {
+
+    this.applicationEventPublisher = applicationEventPublisher;
+  }
+
+  public void publish(final UserData userData) {
+
+    UserDataDeletedEvent userDataDeletedEvent = new UserDataDeletedEvent(
+        this, userData);
+    applicationEventPublisher.publishEvent(userDataDeletedEvent);
+  }
+}

--- a/src/main/java/com/sublinks/sublinksapi/person/repositories/UserDataRepository.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/repositories/UserDataRepository.java
@@ -3,6 +3,7 @@ package com.sublinks.sublinksapi.person.repositories;
 import com.sublinks.sublinksapi.person.dto.Person;
 import com.sublinks.sublinksapi.person.dto.UserData;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,4 +13,9 @@ public interface UserDataRepository extends JpaRepository<UserData, Long> {
 
   Optional<UserData> findFirstByPersonAndIpAddressAndUserAgent(Person person, String ipAddress,
       String userAgent);
+
+  void deleteAllByPerson(Person person);
+
+  List<UserData> findAllByPersonAndLastUsedAtBefore(Person person, Date lastUsedAt);
+  List<UserData> findAllByLastUsedAtBefore(Date lastUsedAt);
 }

--- a/src/main/java/com/sublinks/sublinksapi/person/repositories/UserDataRepository.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/repositories/UserDataRepository.java
@@ -1,0 +1,12 @@
+package com.sublinks.sublinksapi.person.repositories;
+
+import com.sublinks.sublinksapi.person.dto.Person;
+import com.sublinks.sublinksapi.person.dto.UserData;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+
+public interface UserDataRepository extends JpaRepository<UserData, Long> {
+
+  boolean existsUserDataByPersonAndIpAddress(Person person, String ipAddress);
+}

--- a/src/main/java/com/sublinks/sublinksapi/person/repositories/UserDataRepository.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/repositories/UserDataRepository.java
@@ -8,5 +8,8 @@ import java.util.Optional;
 
 public interface UserDataRepository extends JpaRepository<UserData, Long> {
 
-  boolean existsUserDataByPersonAndIpAddress(Person person, String ipAddress);
+  List<UserData> findFirstByPersonAndIpAddress(Person person, String ipAddress);
+
+  Optional<UserData> findFirstByPersonAndIpAddressAndUserAgent(Person person, String ipAddress,
+      String userAgent);
 }

--- a/src/main/java/com/sublinks/sublinksapi/person/scheduling/UserDataScheduler.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/scheduling/UserDataScheduler.java
@@ -1,0 +1,35 @@
+package com.sublinks.sublinksapi.person.scheduling;
+
+import com.sublinks.sublinksapi.instance.models.LocalInstanceContext;
+import com.sublinks.sublinksapi.person.config.CaptchaConfiguration;
+import com.sublinks.sublinksapi.person.config.UserDataConfig;
+import com.sublinks.sublinksapi.person.repositories.CaptchaRepository;
+import com.sublinks.sublinksapi.person.services.CaptchaService;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import com.sublinks.sublinksapi.person.services.UserDataService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableScheduling
+@Configuration
+@RequiredArgsConstructor
+public class UserDataScheduler {
+
+  private final UserDataService userDataService;
+  private final UserDataConfig userDataConfig;
+
+  @Scheduled(fixedRateString = "${sublinks.settings.userdata.clear_rate}", timeUnit = TimeUnit.SECONDS)
+  public void getClearingCaptchaOlderThan() {
+
+    if (userDataConfig.getClearOlderThan() <= 0) {
+      return;
+    }
+    userDataService.clearUserDataBefore(
+        new Date(System.currentTimeMillis() - (userDataConfig.getClearOlderThan() * 1000)));
+  }
+}

--- a/src/main/java/com/sublinks/sublinksapi/person/services/UserDataService.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/services/UserDataService.java
@@ -1,0 +1,39 @@
+package com.sublinks.sublinksapi.person.services;
+
+import com.sublinks.sublinksapi.person.config.UserDataConfig;
+import com.sublinks.sublinksapi.person.dto.Person;
+import com.sublinks.sublinksapi.person.dto.UserData;
+import com.sublinks.sublinksapi.person.repositories.UserDataRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserDataService {
+
+  private final UserDataRepository userDataRepository;
+  private final UserDataConfig userDataConfig;
+
+  public UserData save(UserData userData) {
+
+    return userDataRepository.save(userData);
+  }
+
+  public void delete(UserData userData) {
+
+    userDataRepository.delete(userData);
+  }
+
+  public void checkAndAddIpRelation(Person person, String ipAddress) {
+
+    boolean saveUserIps = userDataConfig.isSaveUserIps();
+    boolean existsUserDataByPersonAndIpAddress = userDataRepository.existsUserDataByPersonAndIpAddress(
+        person, ipAddress);
+    if (saveUserIps && !existsUserDataByPersonAndIpAddress) {
+      UserData userData = new UserData();
+      userData.setPerson(person);
+      userData.setIpAddress(ipAddress);
+      save(userData);
+    }
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,7 +48,7 @@ sublinks.settings.email.starttls=${SUBLINKS_MAIL_STARTTLS:true}
 sublinks.settings.email.starttls.required=${SUBLINKS_MAIL_STARTTLS_REQUIRED:false}
 sublinks.settings.email.debug=${SUBLINKS_MAIL_DEBUG:false}
 sublinks.settings.private_instance=true
-sublinks.settings.userdata.clear_rate={SUBLINKS_USERDATA_CLEAR_RATE_SECONDS:900}
+sublinks.settings.userdata.clear_rate=${SUBLINKS_USERDATA_CLEAR_RATE_SECONDS:900}
 # 90 days in seconds - If 0 or less, userdata clearing is disabled
 sublinks.settings.userdata.clear_older_than=${SUBLINKS_USERDATA_CLEAR_OLDER_THAN_SECONDS:7776000}
 sublinks.pictrs.url=${SUBLINKS_PICTRS_URL}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,6 +48,9 @@ sublinks.settings.email.starttls=${SUBLINKS_MAIL_STARTTLS:true}
 sublinks.settings.email.starttls.required=${SUBLINKS_MAIL_STARTTLS_REQUIRED:false}
 sublinks.settings.email.debug=${SUBLINKS_MAIL_DEBUG:false}
 sublinks.settings.private_instance=true
+sublinks.settings.userdata.clear_rate={SUBLINKS_USERDATA_CLEAR_RATE_SECONDS:900}
+# 90 days in seconds - If 0 or less, userdata clearing is disabled
+sublinks.settings.userdata.clear_older_than=${SUBLINKS_USERDATA_CLEAR_OLDER_THAN_SECONDS:7776000}
 sublinks.pictrs.url=${SUBLINKS_PICTRS_URL}
 sublinks.rate_limits.message=10
 sublinks.rate_limits.message_per_second=10
@@ -70,7 +73,6 @@ sublinks.backend_queue.name=${BACKEND_QUEUE_NAME:}
 sublinks.backend_topic.name=${BACKEND_TOPIC_NAME:}
 sublinks.federation.key=${FEDERATION_ROUTING_KEY:}
 sublinks.federation_queue.name=${{FEDERATION_QUEUE_NAME:}
-
 # If true, the user's IP will be saved in the database
 # This is useful for tracking down spammers BUT it also means that the user's IP will be saved in the database
 # This is a privacy concern, so it is disabled by default, you need to tell the user that their IP will be

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,13 +29,11 @@ sublinks.settings.enable_down_votes=true
 sublinks.settings.enable_nsfw=true
 sublinks.settings.hide_modlog_mod_names=true
 sublinks.settings.actor_name_max_length=20
-
 # 15 minutes ( all in seconds )
 sublinks.settings.captcha.rate=900
 sublinks.settings.captcha.clearing_rate=900
 sublinks.settings.captcha.clearing_older_than=900
 sublinks.settings.captcha.max_captchas=900
-
 sublinks.settings.email.enabled=${SUBLINKS_MAIL_ENABLED:true}
 sublinks.settings.email.host=${SUBLINKS_MAIL_HOST:}
 sublinks.settings.email.port=${SUBLINKS_MAIL_PORT:587}
@@ -49,7 +47,6 @@ sublinks.settings.email.trusted=${SUBLINKS_MAIL_TRUSTED:}
 sublinks.settings.email.starttls=${SUBLINKS_MAIL_STARTTLS:true}
 sublinks.settings.email.starttls.required=${SUBLINKS_MAIL_STARTTLS_REQUIRED:false}
 sublinks.settings.email.debug=${SUBLINKS_MAIL_DEBUG:false}
-
 sublinks.settings.private_instance=true
 sublinks.pictrs.url=${SUBLINKS_PICTRS_URL}
 sublinks.rate_limits.message=10
@@ -68,9 +65,14 @@ spring.rabbitmq.host=${FEDERATION_QUEUE_HOST:}
 spring.rabbitmq.port=${FEDERATION_QUEUE_PORT:}
 spring.rabbitmq.username=${FEDERATION_QUEUE_USER:}
 spring.rabbitmq.password=${FEDERATION_QUEUE_PASS:}
-
 # Sublinks queue configuration
 sublinks.backend_queue.name=${BACKEND_QUEUE_NAME:}
 sublinks.backend_topic.name=${BACKEND_TOPIC_NAME:}
 sublinks.federation.key=${FEDERATION_ROUTING_KEY:}
 sublinks.federation_queue.name=${{FEDERATION_QUEUE_NAME:}
+
+# If true, the user's IP will be saved in the database
+# This is useful for tracking down spammers BUT it also means that the user's IP will be saved in the database
+# This is a privacy concern, so it is disabled by default, you need to tell the user that their IP will be
+# saved according to your privacy policy and/or local laws!
+sublinks.save_user_ips=${SAVE_USER_IP:false}

--- a/src/main/resources/db/migration/V20231003__Create_initial_entity_tables.sql
+++ b/src/main/resources/db/migration/V20231003__Create_initial_entity_tables.sql
@@ -757,10 +757,12 @@ CREATE UNIQUE INDEX `IDX_ROLE_PERMISSIONS_ROLE_ID_PERMISSION` ON `role_permissio
  */
 CREATE TABLE `user_data`
 (
-  `id`         BIGINT AUTO_INCREMENT PRIMARY KEY,
-  `person_id`  BIGINT                                    NOT NULL,
-  `ip_address` VARCHAR(255)                              NOT NULL,
-  `created_at` TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3) NOT NULL
+  `id`           BIGINT AUTO_INCREMENT PRIMARY KEY,
+  `person_id`    BIGINT                                    NOT NULL,
+  `ip_address`   VARCHAR(255)                              NOT NULL,
+  `user_agent`   TEXT                                      NULL,
+  `created_at`   TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3) NOT NULL,
+  `last_used_at` TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3) NOT NULL ON UPDATE CURRENT_TIMESTAMP(3)
 ) ENGINE = InnoDB
   DEFAULT CHARSET `utf8mb4`
   COLLATE = 'utf8mb4_unicode_ci';

--- a/src/main/resources/db/migration/V20231003__Create_initial_entity_tables.sql
+++ b/src/main/resources/db/migration/V20231003__Create_initial_entity_tables.sql
@@ -751,3 +751,16 @@ CREATE TABLE `role_permissions`
 
 CREATE INDEX `IDX_ROLE_PERMISSIONS_ROLE_ID` ON `role_permissions` (`role_id`);
 CREATE UNIQUE INDEX `IDX_ROLE_PERMISSIONS_ROLE_ID_PERMISSION` ON `role_permissions` (role_id, permission(255));
+
+/**
+  User Data table
+ */
+CREATE TABLE `user_data`
+(
+  `id`         BIGINT AUTO_INCREMENT PRIMARY KEY,
+  `person_id`  BIGINT                                    NOT NULL,
+  `ip_address` VARCHAR(255)                              NOT NULL,
+  `created_at` TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3) NOT NULL
+) ENGINE = InnoDB
+  DEFAULT CHARSET `utf8mb4`
+  COLLATE = 'utf8mb4_unicode_ci';


### PR DESCRIPTION
Added a new table `user_data` to store user information including IPs, along with services, configurations, and repositories to support the function. This feature is opt-in and can be activated by changing the `sublinks.save_user_ips` setting in `application.properties`. This is a privacy concern as it stores user IPs, thus is disabled by default. Therefore, properly inform the user as per your privacy policy and/or local laws.

closes #153 