### PR TITLE
Added Jacoco Test Coverage Report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.3'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'jacoco'
 }
 
 group = 'com.sublinks'


### PR DESCRIPTION
Jacoco Test Report Coverage Plugin (https://docs.gradle.org/current/userguide/jacoco_plugin.html)

With the issues for unit testing (#246 #245 #244 #243 #242 #241 #240 #239 #238) that have been added, it may be good to add a test coverage report, if only for informational cases. This PR does not add any requirements for code coverage for builds.

This can also be rolled into one of the PRs for Unit testing as well or closed if it's been discussed already (I can't seem to find mention of the plugin in anything closed)

