### PR TITLE
Change to use Dockerfile to build multi-arch images

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,6 +12,8 @@ on:
     - cron: '29 0 * * *'
   push:
     branches: [ "main" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
 
@@ -20,8 +22,10 @@ permissions:
   packages: write
 
 env:
-  DOCKER_USER: ${{ github.actor }}
-  DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -39,8 +43,41 @@ jobs:
       uses: gradle/gradle-build-action@v3
       with:
         arguments: build
-    - name: Build Docker Image
+
+    # Set up BuildKit Docker container builder to be able to build
+    # multi-platform images and export cache
+    # https://github.com/docker/setup-buildx-action
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c # v3.1.0
+
+    # Login against a Docker registry except on PR
+    # https://github.com/docker/login-action
+    - name: Log into registry ${{ env.REGISTRY }}
       if: github.event_name != 'pull_request'
-      uses: gradle/gradle-build-action@v3
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
       with:
-        arguments: bootBuildImage
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    # Extract metadata (tags, labels) for Docker
+    # https://github.com/docker/metadata-action
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    # Build and push Docker image with Buildx (don't push on PR)
+    # https://github.com/docker/build-push-action
+    - name: Build and push Docker image
+      id: build-and-push
+      uses: docker/build-push-action@af5a7ed5ba88268d5278f7203fb52cd833f66d6e # v5.2.0
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM eclipse-temurin:17-jre-ubi9-minimal
+LABEL maintainer="Sublinks Core Developers <hello@sublinks.org>"
+LABEL description="Backend API service for Sublinks"
+
+WORKDIR /app
+COPY build/libs/sublinks-api-*.jar /app/sublinks-api.jar
+
+EXPOSE 8080
+CMD ["java", "-jar", "sublinks-api.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -95,3 +95,9 @@ tasks.named("bootBuildImage") {
         }
     }
 }
+
+tasks.named("jar") {
+    // Disable generation of the "plain" jar file and just generate the fat jar file
+    // See https://docs.spring.io/spring-boot/docs/3.2.3/gradle-plugin/reference/htmlsingle/#packaging-executable.and-plain-archives
+    enabled = false
+}


### PR DESCRIPTION
This PR changes from using the Gradle task `bootBuildImage` to use a custom Dockerfile. This is needed as the buildpacks used by SpringBoot do not support generating arm64 images. I've copied the workflow content from the federation service here so that the docker image generation is the same for both services. Additionally, I needed to disable the generation of the "-plain.jar" file to avoid confusion when building the docker image. The difference between the "-plain.jar" file and the other jar file is that the "plain" one contains only the compiled code from the service. It doesn't contain any of the libraries required to actually run the service. Since it is unlikely we would need this for anything, I believe it is fine to disable it (normally it's used when generating a "native application", but since that is architecture specific based on the system generating it, it also has the problem of not being multi-arch).