### PR TITLE
Update fetching strategy and clean up code

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/services/LemmyPersonService.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/services/LemmyPersonService.java
@@ -8,15 +8,18 @@ import com.sublinks.sublinksapi.api.lemmy.v3.post.services.LemmyPostService;
 import com.sublinks.sublinksapi.api.lemmy.v3.user.models.PersonAggregates;
 import com.sublinks.sublinksapi.api.lemmy.v3.user.models.PersonView;
 import com.sublinks.sublinksapi.authorization.services.RoleAuthorizingService;
+import com.sublinks.sublinksapi.comment.dto.Comment;
 import com.sublinks.sublinksapi.person.dto.Person;
 import com.sublinks.sublinksapi.person.enums.LinkPersonCommunityType;
 import com.sublinks.sublinksapi.person.services.LinkPersonCommunityService;
 import com.sublinks.sublinksapi.post.repositories.PostRepository;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -56,9 +59,9 @@ public class LemmyPersonService {
     Collection<CommunityModeratorView> communityModeratorViews = new ArrayList<>();
     linkPersonCommunityService.getPersonLinkByType(person, LinkPersonCommunityType.moderator)
         .forEach(community -> {
-          communityModeratorViews.add(CommunityModeratorView.builder().community(
-                  conversionService.convert(community,
-                      com.sublinks.sublinksapi.api.lemmy.v3.community.models.Community.class))
+          communityModeratorViews.add(CommunityModeratorView.builder()
+              .community(conversionService.convert(community,
+                  com.sublinks.sublinksapi.api.lemmy.v3.community.models.Community.class))
               .moderator(conversionService.convert(person,
                   com.sublinks.sublinksapi.api.lemmy.v3.user.models.Person.class))
               .build());
@@ -66,13 +69,14 @@ public class LemmyPersonService {
     return communityModeratorViews;
   }
 
+  @Transactional
   public Collection<CommentView> getPersonComments(Person person) {
 
     Collection<CommentView> commentViews = new ArrayList<>();
 
-    // @TODO: Fix this?!???
-//    person.getComments().forEach(
-//            comment -> commentViews.add(lemmyCommentService.createCommentView(comment, person)));
+    person.getComments()
+        .forEach(
+            comment -> commentViews.add(lemmyCommentService.createCommentView(comment, person)));
 
     return commentViews;
   }

--- a/src/main/java/com/sublinks/sublinksapi/person/dto/Person.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/dto/Person.java
@@ -78,7 +78,7 @@ public class Person implements UserDetails, Principal {
   @OneToMany(mappedBy = "person")
   private List<UserData> userData;
 
-  @OneToMany
+  @OneToMany(fetch = FetchType.EAGER, mappedBy = "person")
   @PrimaryKeyJoinColumn
   private List<Comment> comments;
 
@@ -325,6 +325,7 @@ public class Person implements UserDetails, Principal {
   public final int hashCode() {
 
     return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer()
-        .getPersistentClass().hashCode() : getClass().hashCode();
+        .getPersistentClass()
+        .hashCode() : getClass().hashCode();
   }
 }


### PR DESCRIPTION
Fetched comments in 'Person.java' has been changed to EAGER from default LAZY to provide immediate loading. This change in strategy removes the need for a workaround code on the service layer in 'LemmyPersonService.java'. The commented-out code is also cleaned, resulting in a more readable and straightforward implementation.