### PR TITLE
Add handling for SignatureException in JwtFilter

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/authentication/JwtFilter.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/authentication/JwtFilter.java
@@ -4,6 +4,7 @@ import com.sublinks.sublinksapi.person.dto.Person;
 import com.sublinks.sublinksapi.person.repositories.PersonRepository;
 import com.sublinks.sublinksapi.person.services.UserDataService;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -29,10 +30,9 @@ public class JwtFilter extends OncePerRequestFilter {
   private final UserDataService userDataService;
 
   @Override
-  protected void doFilterInternal(
-      final HttpServletRequest request,
-      final HttpServletResponse response,
-      final FilterChain filterChain) throws ServletException, IOException {
+  protected void doFilterInternal(final HttpServletRequest request,
+      final HttpServletResponse response, final FilterChain filterChain)
+      throws ServletException, IOException {
 
     String authorizingToken = request.getHeader("authorization");
 
@@ -58,8 +58,8 @@ public class JwtFilter extends OncePerRequestFilter {
         }
         userName = jwtUtil.extractUsername(token);
       }
-    } catch (ExpiredJwtException ex) {
-      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    } catch (ExpiredJwtException | SignatureException ex) {
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "invalid_token");
     }
 
     if (userName != null && SecurityContextHolder.getContext().getAuthentication() == null) {


### PR DESCRIPTION
The JwtFilter has been updated to catch SignatureExceptions alongside ExpiredJwtExceptions. This provides enhanced error handling in this area. Additionally, to provide more detailed feedback on errors, the response now sends an "invalid_token" message when these exceptions are thrown.

closes #274 