### PR TITLE
Fixed that userdata is correctly saved only if the config is set.

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/person/config/UserDataConfig.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/config/UserDataConfig.java
@@ -1,6 +1,5 @@
 package com.sublinks.sublinksapi.person.config;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -9,8 +8,8 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 public class UserDataConfig {
 
-  @Value("${sublinks.save_user_ips}")
-  private boolean saveUserIps;
+  @Value("${sublinks.save_user_data}")
+  private boolean saveUserData;
 
   @Value("${sublinks.settings.userdata.clear_rate}")
   private long clearRate;

--- a/src/main/java/com/sublinks/sublinksapi/person/entities/PersonEmailVerification.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/entities/PersonEmailVerification.java
@@ -29,7 +29,7 @@ public class PersonEmailVerification {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, name = "ip_address")
+  @Column(nullable = true, name = "ip_address")
   private String ipAddress;
 
   @Column(nullable = true, name = "user_agent")

--- a/src/main/java/com/sublinks/sublinksapi/person/repositories/UserDataRepository.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/repositories/UserDataRepository.java
@@ -14,7 +14,7 @@ public interface UserDataRepository extends JpaRepository<UserData, Long> {
 
   List<UserData> findFirstByPersonAndIpAddress(Person person, String ipAddress);
 
-  Optional<UserData> findFirstByPersonAndIpAddressAndUserAgent(Person person, String ipAddress,
+  Optional<UserData> findFirstByPersonAndIpAddressAndUserAgentAndActiveIsTrue(Person person, String ipAddress,
       String userAgent);
 
   Optional<UserData> findFirstByPersonAndTokenAndIpAddressAndUserAgentAndActiveIsTrue(Person person,
@@ -25,11 +25,13 @@ public interface UserDataRepository extends JpaRepository<UserData, Long> {
 
   Optional<UserData> findFirstByPersonAndTokenAndActiveIsTrue(Person person, String token);
 
-  @Modifying
-  @Query("update UserData u set u.active = false where u.person = :person")
-  void updateAllByPersonSetActiveToFalse(@Param(value = "person") Person person);
 
   List<UserData> findAllByPersonAndLastUsedAtBefore(Person person, Date lastUsedAt);
 
   List<UserData> findAllByLastUsedAtBefore(Date lastUsedAt);
+
+
+  @Modifying
+  @Query("update UserData u set u.active = false where u.person = :person")
+  void updateAllByPersonSetActiveToFalse(@Param(value = "person") Person person);
 }

--- a/src/main/java/com/sublinks/sublinksapi/person/services/PersonEmailVerificationService.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/services/PersonEmailVerificationService.java
@@ -1,5 +1,6 @@
 package com.sublinks.sublinksapi.person.services;
 
+import com.sublinks.sublinksapi.person.config.UserDataConfig;
 import com.sublinks.sublinksapi.person.entities.Person;
 import com.sublinks.sublinksapi.person.entities.PersonEmailVerification;
 import com.sublinks.sublinksapi.person.events.PersonEmailVerificationCreatedEventPublisher;
@@ -18,13 +19,15 @@ public class PersonEmailVerificationService {
   private final PersonEmailVerificationUpdatedEventPublisher personEmailVerificationUpdatedEventPublisher;
   private final PersonEmailVerificationRepository personEmailVerificationRepository;
 
+  private final UserDataConfig userDataConfig;
+
   public PersonEmailVerification create(Person person, String ipAddress, String userAgent) {
 
     PersonEmailVerification personEmailVerification = new PersonEmailVerification();
     personEmailVerification.setPerson(person);
     personEmailVerification.setToken(UUID.randomUUID().toString());
-    personEmailVerification.setIpAddress(ipAddress);
-    personEmailVerification.setUserAgent(userAgent);
+    personEmailVerification.setIpAddress(userDataConfig.isSaveUserData() ? ipAddress : null);
+    personEmailVerification.setUserAgent(userDataConfig.isSaveUserData() ? userAgent : null);
     personEmailVerification.setActive(true);
 
     personEmailVerificationRepository.save(personEmailVerification);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -79,7 +79,7 @@ sublinks.federation_queue.name=${{FEDERATION_QUEUE_NAME:}
 # This is useful for tracking down spammers BUT it also means that the user's IP will be saved in the database
 # This is a privacy concern, so it is disabled by default, you need to tell the user that their IP will be
 # saved according to your privacy policy and/or local laws!
-sublinks.save_user_ips=${SAVE_USER_IP:false}
+sublinks.save_user_data=${SAVE_USER_DATA:false}
 sublinks.keep_post_history=${KEEP_POST_HISTORY:false}
 sublinks.keep_comment_history=${KEEP_COMMENT_HISTORY:false}
 

--- a/src/main/resources/db/migration/V20231003__Create_initial_entity_tables.sql
+++ b/src/main/resources/db/migration/V20231003__Create_initial_entity_tables.sql
@@ -828,7 +828,7 @@ CREATE TABLE `person_email_verification`
   `id`         BIGINT AUTO_INCREMENT PRIMARY KEY,
   `person_id`  BIGINT       NOT NULL,
   `token`      VARCHAR(255) NOT NULL,
-  `ip_address` VARCHAR(255) NOT NULL,
+  `ip_address` VARCHAR(255) NULL,
   `user_agent` TEXT         NULL,
   `active`     TINYINT      NOT NULL DEFAULT 1,
   `created_at` TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),


### PR DESCRIPTION
This update modifies the handling of user data in the PersonEmailVerification service, UserData service and UserData repository. User data (like IP address and user agent) is now saved or not based on the "sublinks.save_user_data" configuration property. This adds an extra layer of control and privacy customization to the application. Database schema and queries have been revised to accommodate this functionality.