### PR TITLE
Update entity properties and add mark all as read functionality

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/comment/controllers/CommentController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/comment/controllers/CommentController.java
@@ -294,7 +294,7 @@ public class CommentController extends AbstractLemmyApiController {
 
     if (commentReply.isPresent()) {
       CommentReply commentReplyEntity = commentReply.get();
-      commentReplyEntity.setIsRead(true);
+      commentReplyEntity.setRead(true);
       commentReplyService.updateCommentReply(commentReplyEntity);
     }
 

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/comment/mappers/CommentReplyMapper.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/comment/mappers/CommentReplyMapper.java
@@ -16,6 +16,6 @@ public interface CommentReplyMapper extends
   @Mapping(target = "published", source = "commentReply.createdAt", dateFormat = DateUtils.FRONT_END_DATE_FORMAT)
   @Mapping(target = "comment_id", source = "commentReply.comment.id")
   @Mapping(target = "recipient_id", source = "commentReply.recipient.id")
-  @Mapping(target = "read", source = "commentReply.isRead")
+  @Mapping(target = "read", source = "commentReply.read")
   CommentReply convert(@Nullable com.sublinks.sublinksapi.comment.entities.CommentReply commentReply);
 }

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/comment/models/GetReplies.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/comment/models/GetReplies.java
@@ -11,7 +11,7 @@ public record GetReplies(
     CommentReplySortType sort,
     Integer page,
     Integer limit,
-    Boolean unread_only
+    Optional<Boolean> unread_only
 ) {
 
 }

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/privatemessage/controllers/PrivateMessageController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/privatemessage/controllers/PrivateMessageController.java
@@ -93,6 +93,7 @@ public class PrivateMessageController extends AbstractLemmyApiController {
         .perPage(perPage)
         .privateMessageSortType(sortType)
         .person(sender)
+        .unreadOnly(getPrivateMessagesForm.unread_only().orElse(false))
         .build();
 
     final List<PrivateMessage> privateMessages = privateMessageRepository.allPrivateMessagesBySearchCriteria(
@@ -313,7 +314,8 @@ public class PrivateMessageController extends AbstractLemmyApiController {
         PrivateMessageReportSearchCriteria.builder()
             .page(page)
             .perPage(perPage)
-            .unresolvedOnly(listPrivateMessageReportsForm.unresolved_only() != null && listPrivateMessageReportsForm.unresolved_only())
+            .unresolvedOnly(listPrivateMessageReportsForm.unresolved_only() != null
+                && listPrivateMessageReportsForm.unresolved_only())
             .build());
 
     final List<PrivateMessageReportView> privateMessageReportViews = new ArrayList<>();

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/privatemessage/models/GetPrivateMessages.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/privatemessage/models/GetPrivateMessages.java
@@ -1,14 +1,15 @@
 package com.sublinks.sublinksapi.api.lemmy.v3.privatemessage.models;
 
 import lombok.Builder;
+import java.util.Optional;
 
 @Builder
 @SuppressWarnings("RecordComponentName")
 public record GetPrivateMessages(
-    Boolean unread_only,
     Integer page,
     Integer limit,
-    Long creator_id
+    Long creator_id,
+    Optional<Boolean> unread_only
 ) {
 
 }

--- a/src/main/java/com/sublinks/sublinksapi/comment/entities/CommentReply.java
+++ b/src/main/java/com/sublinks/sublinksapi/comment/entities/CommentReply.java
@@ -49,7 +49,7 @@ public class CommentReply implements Serializable {
   private Long id;
 
   @Column(nullable = false, name = "is_read")
-  private Boolean isRead;
+  private boolean isRead;
 
   @CreationTimestamp
   @Column(updatable = false, nullable = false, name = "created_at")

--- a/src/main/java/com/sublinks/sublinksapi/comment/repositories/CommentReplyRepository.java
+++ b/src/main/java/com/sublinks/sublinksapi/comment/repositories/CommentReplyRepository.java
@@ -3,9 +3,16 @@ package com.sublinks.sublinksapi.comment.repositories;
 import com.sublinks.sublinksapi.comment.entities.CommentReply;
 import com.sublinks.sublinksapi.person.entities.Person;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
 
 public interface CommentReplyRepository extends JpaRepository<CommentReply, Long>,
     CommentReplyRepositorySearch {
 
-  long countByRecipientAndIsReadFalse(Person recipient);
+  @Query("SELECT COUNT(cr) FROM CommentReply cr WHERE cr.recipient = :recipient AND cr.isRead = false AND cr.comment.isDeleted = false AND cr.comment.removedState = 'NOT_REMOVED'")
+  long countByRecipientAndReadIsFalse(@Param("recipient") Person recipient);
+
+  @Query("SELECT cr FROM CommentReply cr WHERE cr.recipient = :recipient AND cr.isRead = false AND cr.comment.isDeleted = false AND cr.comment.removedState = 'NOT_REMOVED'")
+  List<CommentReply> findAllByRecipientAndReadIsFalse(@Param("recipient") Person recipient);
 }

--- a/src/main/java/com/sublinks/sublinksapi/person/entities/UserData.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/entities/UserData.java
@@ -40,7 +40,7 @@ public class UserData {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, name = "ip_address")
+  @Column(nullable = true, name = "ip_address")
   private String ipAddress;
 
   @Column(nullable = true, name = "user_agent")

--- a/src/main/java/com/sublinks/sublinksapi/person/repositories/PersonMentionRepository.java
+++ b/src/main/java/com/sublinks/sublinksapi/person/repositories/PersonMentionRepository.java
@@ -3,9 +3,16 @@ package com.sublinks.sublinksapi.person.repositories;
 import com.sublinks.sublinksapi.person.entities.Person;
 import com.sublinks.sublinksapi.person.entities.PersonMention;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
 
 public interface PersonMentionRepository extends JpaRepository<PersonMention, Long>,
     PersonMentionRepositorySearch {
 
-  long countByRecipientAndIsReadFalse(Person recipient);
+  @Query("SELECT COUNT(pm) FROM PersonMention pm WHERE pm.recipient = :recipient AND pm.isRead = false AND pm.comment.isDeleted = false AND pm.comment.removedState = 'NOT_REMOVED'")
+  long countByRecipientAndIsReadIsFalse(@Param("recipient") Person recipient);
+
+  @Query("SELECT pm FROM PersonMention pm WHERE pm.recipient = :recipient AND pm.isRead = false AND pm.comment.isDeleted = false AND pm.comment.removedState = 'NOT_REMOVED'")
+  List<PersonMention> findAllByRecipientAndReadIsFalse(@Param("recipient") Person recipient);
 }

--- a/src/main/java/com/sublinks/sublinksapi/privatemessages/models/MarkAllAsReadResponse.java
+++ b/src/main/java/com/sublinks/sublinksapi/privatemessages/models/MarkAllAsReadResponse.java
@@ -1,0 +1,16 @@
+package com.sublinks.sublinksapi.privatemessages.models;
+
+import com.sublinks.sublinksapi.comment.entities.CommentReply;
+import com.sublinks.sublinksapi.person.entities.PersonMention;
+import com.sublinks.sublinksapi.privatemessages.entities.PrivateMessage;
+import lombok.Builder;
+import java.util.List;
+
+@Builder
+public record MarkAllAsReadResponse(
+    List<PrivateMessage> privateMessages,
+    List<CommentReply> commentReplies,
+    List<PersonMention> personMentions
+) {
+
+}

--- a/src/main/java/com/sublinks/sublinksapi/privatemessages/models/PrivateMessageSearchCriteria.java
+++ b/src/main/java/com/sublinks/sublinksapi/privatemessages/models/PrivateMessageSearchCriteria.java
@@ -9,7 +9,7 @@ public record PrivateMessageSearchCriteria(
     PrivateMessageSortType privateMessageSortType,
     int perPage,
     int page,
-    boolean unresolvedOnly,
+    boolean unreadOnly,
     Person person
 ) {
 

--- a/src/main/java/com/sublinks/sublinksapi/privatemessages/repositories/PrivateMessageRepository.java
+++ b/src/main/java/com/sublinks/sublinksapi/privatemessages/repositories/PrivateMessageRepository.java
@@ -3,10 +3,16 @@ package com.sublinks.sublinksapi.privatemessages.repositories;
 import com.sublinks.sublinksapi.person.entities.Person;
 import com.sublinks.sublinksapi.privatemessages.entities.PrivateMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
 
 public interface PrivateMessageRepository extends JpaRepository<PrivateMessage, Long>,
     PrivateMessageRepositorySearch {
 
-  long countByRecipientAndIsReadFalse(Person recipient);
+  @Query("SELECT COUNT(pm) FROM PrivateMessage pm WHERE pm.recipient = :recipient AND pm.isRead = false AND pm.isDeleted = false")
+  long countByRecipientAndReadIsFalse(@Param("recipient") Person recipient);
 
+  @Query("SELECT pm FROM PrivateMessage pm WHERE pm.recipient = :recipient AND pm.isRead = false AND pm.isDeleted = false")
+  List<PrivateMessage> findByRecipientAndReadIsFalse(@Param("recipient") Person recipient);
 }

--- a/src/main/java/com/sublinks/sublinksapi/privatemessages/repositories/PrivateMessageRepositoryImpl.java
+++ b/src/main/java/com/sublinks/sublinksapi/privatemessages/repositories/PrivateMessageRepositoryImpl.java
@@ -29,8 +29,8 @@ public class PrivateMessageRepositoryImpl implements PrivateMessageRepositorySea
     final Root<PrivateMessage> privateMessageTable = cq.from(PrivateMessage.class);
     final List<Predicate> predicates = new ArrayList<>();
 
-    if (privateMessageSearchCriteria.unresolvedOnly()) {
-      predicates.add(cb.equal(privateMessageTable.get("resolved"), false));
+    if (privateMessageSearchCriteria.unreadOnly()) {
+      predicates.add(cb.equal(privateMessageTable.get("isRead"), false));
     }
 
     if (privateMessageSearchCriteria.person() != null) {

--- a/src/main/resources/db/migration/V20231003__Create_initial_entity_tables.sql
+++ b/src/main/resources/db/migration/V20231003__Create_initial_entity_tables.sql
@@ -760,7 +760,7 @@ CREATE TABLE `user_data`
   `id`           BIGINT AUTO_INCREMENT PRIMARY KEY,
   `person_id`    BIGINT                                    NOT NULL,
   `token`        VARCHAR(255)                              NOT NULL,
-  `ip_address`   VARCHAR(255)                              NOT NULL,
+  `ip_address`   VARCHAR(255)                              NULL,
   `user_agent`   TEXT                                      NULL,
   `active`       TINYINT                                   NOT NULL DEFAULT 1,
   `created_at`   TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3) NOT NULL,


### PR DESCRIPTION
Changed nullable property for ip_address and altered boolean field in UserDate and CommentReply entities respectively. Implemented 'mark all as read' functionality in UserController and PrivateMessageService which marks all private messages, comment replies, and person mentions as read. Adjusted queries in relevant repositories to support this change. Numerous minor adjustments were made across various other classes to enhance code readability and maintain consistency.

closes #322 