### PR TITLE
Add request validation to various methods

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/comment/controllers/CommentController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/comment/controllers/CommentController.java
@@ -239,7 +239,7 @@ public class CommentController extends AbstractLemmyApiController {
   @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
       @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CommentResponse.class))})})
   @PostMapping("delete")
-  CommentResponse delete(@RequestBody final DeleteComment deleteCommentForm,
+  CommentResponse delete(@Valid @RequestBody final DeleteComment deleteCommentForm,
       final JwtPerson principal) {
     // @todo Implement delete comment
     final Person person = getPersonOrThrowUnauthorized(principal);
@@ -369,7 +369,7 @@ public class CommentController extends AbstractLemmyApiController {
   @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
       @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CommentResponse.class))})})
   @PutMapping("save")
-  CommentResponse saveForLater(@RequestBody final SaveComment saveCommentForm,
+  CommentResponse saveForLater(@Valid @RequestBody final SaveComment saveCommentForm,
       final JwtPerson principal) {
 
     final Person person = getPersonOrThrowUnauthorized(principal);

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/privatemessage/controllers/PrivateMessageController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/privatemessage/controllers/PrivateMessageController.java
@@ -313,7 +313,8 @@ public class PrivateMessageController extends AbstractLemmyApiController {
         PrivateMessageReportSearchCriteria.builder()
             .page(page)
             .perPage(perPage)
-            .unresolvedOnly(listPrivateMessageReportsForm.unresolved_only() != null && listPrivateMessageReportsForm.unresolved_only())
+            .unresolvedOnly(listPrivateMessageReportsForm.unresolved_only() != null
+                && listPrivateMessageReportsForm.unresolved_only())
             .build());
 
     final List<PrivateMessageReportView> privateMessageReportViews = new ArrayList<>();

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
@@ -416,7 +416,7 @@ public class UserAuthController extends AbstractLemmyApiController {
   @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
       @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = VerifyEmailResponse.class))})})
   @PostMapping("verify_email")
-  SuccessResponse verifyEmail(@RequestBody VerifyEmail verifyEmailForm) {
+  SuccessResponse verifyEmail(@Valid @RequestBody VerifyEmail verifyEmailForm) {
 
     Optional<PersonEmailVerification> personEmailVerification = personEmailVerificationService.getActiveVerificationByToken(
         verifyEmailForm.token());


### PR DESCRIPTION
Validation annotations (@Valid) were added to the request bodies in delete, saveForLater, and verifyEmail methods in CommentController, UserAuthController respectively. A long line of code in PrivateMessageController was also split for better readability.