### PR TITLE
Fix typo in README for Docker command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ experience, content authenticity, and networked social interaction
 To use this Docker setup you first need to complete a few steps:
 
 - Run `git submodule update --init --recursive` to pull down all submodules
-- `API_HOST=host.docker.internal docker-compose -f docker/docker-compose.backend.yaml up [-d]`
+- `API_HOST=host.docker.internal docker-compose -f docker/docker-compose.backend.yml up [-d]`
     - `-d` to run in detached mode (don't include the [] brackets, they indicate
       being optional)
     - NOTE: The UI service will fail unless the API is already running. However,


### PR DESCRIPTION
The upstream uses `yml` not `yaml`. This fixes that.