### PR TITLE
Add search by parent comment functionality

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/comment/entities/Comment.java
+++ b/src/main/java/com/sublinks/sublinksapi/comment/entities/Comment.java
@@ -92,7 +92,6 @@ public class Comment implements Serializable, AclEntityInterface {
 
   @Column(nullable = false, name = "removed_state")
   @Enumerated(EnumType.STRING)
-
   private RemovedState removedState;
 
   @Column(nullable = false, name = "is_local")
@@ -111,7 +110,7 @@ public class Comment implements Serializable, AclEntityInterface {
   @Column(updatable = false, nullable = false, name = "created_at")
   private Date createdAt;
 
-  
+
   @UpdateTimestamp(source = SourceType.DB)
   @Column(updatable = false, name = "updated_at")
   private Date updatedAt;
@@ -142,7 +141,8 @@ public class Comment implements Serializable, AclEntityInterface {
   public final int hashCode() {
 
     return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer()
-        .getPersistentClass().hashCode() : getClass().hashCode();
+        .getPersistentClass()
+        .hashCode() : getClass().hashCode();
   }
 
   public boolean isRemoved() {

--- a/src/main/java/com/sublinks/sublinksapi/comment/models/CommentSearchCriteria.java
+++ b/src/main/java/com/sublinks/sublinksapi/comment/models/CommentSearchCriteria.java
@@ -9,16 +9,15 @@ import com.sublinks.sublinksapi.post.entities.Post;
 import lombok.Builder;
 
 @Builder
-public record CommentSearchCriteria(
-    ListingType listingType,
-    CommentSortType commentSortType,
-    int perPage,
-    int page,
-    Community community,
-    Post post,
-    Comment parent,
-    boolean savedOnly,
-    Person person
-) {
+public record CommentSearchCriteria(ListingType listingType,
+                                    CommentSortType commentSortType,
+                                    Integer perPage,
+                                    Integer page,
+                                    Integer maxDepth,
+                                    Community community,
+                                    Post post,
+                                    Comment parent,
+                                    Boolean savedOnly,
+                                    Person person) {
 
 }

--- a/src/main/java/com/sublinks/sublinksapi/comment/repositories/CommentRepositoryImpl.java
+++ b/src/main/java/com/sublinks/sublinksapi/comment/repositories/CommentRepositoryImpl.java
@@ -36,6 +36,13 @@ public class CommentRepositoryImpl implements CommentRepositorySearch {
     final Root<Comment> commentTable = cq.from(Comment.class);
 
     final List<Predicate> predicates = new ArrayList<>();
+
+    // Parent Comment
+    if (commentSearchCriteria.parent() != null) {
+      predicates.add(cb.like(commentTable.get("path"), commentSearchCriteria.parent()
+          .getPath() + ".%"));
+    }
+
     // Post
     if (commentSearchCriteria.post() != null) {
       predicates.add(cb.equal(commentTable.get("post"), commentSearchCriteria.post()));
@@ -103,7 +110,8 @@ public class CommentRepositoryImpl implements CommentRepositorySearch {
 
     cq.where(predicates.toArray(new Predicate[0]));
 
-    return em.createQuery(cq).getResultList();
+    return em.createQuery(cq)
+        .getResultList();
   }
 
   @Override
@@ -130,6 +138,7 @@ public class CommentRepositoryImpl implements CommentRepositorySearch {
 
     cq.where(predicates.toArray(new Predicate[0]));
 
-    return em.createQuery(cq).getResultList();
+    return em.createQuery(cq)
+        .getResultList();
   }
 }

--- a/src/main/java/com/sublinks/sublinksapi/comment/repositories/CommentRepositoryImpl.java
+++ b/src/main/java/com/sublinks/sublinksapi/comment/repositories/CommentRepositoryImpl.java
@@ -38,17 +38,17 @@ public class CommentRepositoryImpl implements CommentRepositorySearch {
     final List<Predicate> predicates = new ArrayList<>();
 
     // Parent Comment
+    int maxDepth = commentSearchCriteria.maxDepth() != null && commentSearchCriteria.maxDepth() > 0
+        ? commentSearchCriteria.maxDepth() : 2;
+
+    String regex = "^0\\.(?:[0-9]+\\.?){1," + (maxDepth + 1) + "}$";
+
     if (commentSearchCriteria.parent() != null) {
-      int maxDepth = commentSearchCriteria.maxDepth() > 0 ? commentSearchCriteria.maxDepth() : 2;
-
-      // Use regexp_like to match the parent comment path with the specific depth
-
-      String regex = "^" + commentSearchCriteria.parent()
-          .getPath() + "\\.(?:[0-9]+\\.?){1," + maxDepth + "}$";
-
-      predicates.add(cb.isTrue(
-          cb.function("regexp_like", Boolean.class, commentTable.get("path"), cb.literal(regex))));
+      regex = "^" + commentSearchCriteria.parent()
+          .getPath() + "\\.(?:[0-9]+\\.?){1," + (maxDepth + 1) + "}$";
     }
+    predicates.add(cb.isTrue(
+        cb.function("regexp_like", Boolean.class, commentTable.get("path"), cb.literal(regex))));
 
     // Post
     if (commentSearchCriteria.post() != null) {
@@ -82,7 +82,7 @@ public class CommentRepositoryImpl implements CommentRepositorySearch {
     }
 
     final int perPage = Math.min(Math.abs(commentSearchCriteria.perPage()), 50);
-    final int page = Math.max(commentSearchCriteria.page() - 1, 0);
+    final int page = Math.max(commentSearchCriteria.page() - 1, 1);
 
     final TypedQuery<Comment> query = em.createQuery(cq);
 


### PR DESCRIPTION
The CommentSearchCriteria now includes the option to search for comments based on their parent comment. This added functionality allows for more specific and organized comment retrieval, improving data filtering mechanisms. Any code calling this search function can now also filter comments by their parent comment.