### PR TITLE
Add org.flywaydb:flyway-database-postgresql dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.flywaydb:flyway-core'
   implementation 'org.flywaydb:flyway-mysql'
+  implementation 'org.flywaydb:flyway-database-postgresql'
   implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation 'org.springframework.boot:spring-boot-starter-security'
   implementation 'org.springframework.boot:spring-boot-starter-amqp'


### PR DESCRIPTION
Per https://github.com/flyway/flyway/issues/3780 v10 of Flyway split out into modules. We already have the mysql module, but when the database was switched to Postgres we never added the postgres module