### PR TITLE
Implemented Community Ban logic and Improved Handling of ACL Service

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/admin/controllers/AdminController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/admin/controllers/AdminController.java
@@ -101,6 +101,7 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionInstanceTypes.INSTANCE_ADD_ADMIN)
+        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     final Person personToAdd = personRepository.findById((long) addAdminForm.person_id())
@@ -142,6 +143,7 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionInstanceTypes.INSTANCE_REMOVE_ADMIN)
+        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     return GetUnreadRegistrationApplicationCountResponse.builder().registration_applications(
@@ -161,6 +163,7 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionRegistrationApplicationTypes.REGISTRATION_APPLICATION_READ)
+        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     final List<PersonRegistrationApplication> personRegistrationApplications = personRegistrationApplicationRepository.findAllByApplicationStatus(
@@ -185,6 +188,7 @@ public class AdminController extends AbstractLemmyApiController {
     aclService.canPerson(person)
         .performTheAction(
             RolePermissionRegistrationApplicationTypes.REGISTRATION_APPLICATION_UPDATE)
+        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     final PersonRegistrationApplication personRegistrationApplication = personRegistrationApplicationRepository.findById(
@@ -217,6 +221,7 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionPersonTypes.PURGE_USER)
+        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     final Person personToPurge = personRepository.findById((long) purgePersonForm.person_id())
@@ -241,6 +246,7 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionCommunityTypes.PURGE_COMMUNITY)
+        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     throw new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED);
@@ -257,6 +263,7 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionPostTypes.PURGE_POST)
+        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     final Post postToPurge = postRepository.getReferenceById((long) purgePostForm.post_id());
@@ -282,6 +289,7 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionCommentTypes.PURGE_COMMENT)
+        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     final Comment commentToPurge = commentRepository.getReferenceById(

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/admin/controllers/AdminController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/admin/controllers/AdminController.java
@@ -92,8 +92,10 @@ public class AdminController extends AbstractLemmyApiController {
   private final AclService aclService;
 
   @Operation(summary = "Add an admin to your site.")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = AddAdminResponse.class))})})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = AddAdminResponse.class))})})
   @PostMapping("add")
   AddAdminResponse create(@Valid @RequestBody final AddAdmin addAdminForm, JwtPerson principal) {
 
@@ -101,7 +103,6 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionInstanceTypes.INSTANCE_ADD_ADMIN)
-        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     final Person personToAdd = personRepository.findById((long) addAdminForm.person_id())
@@ -127,13 +128,19 @@ public class AdminController extends AbstractLemmyApiController {
         .build();
     moderationLogService.createModerationLog(moderationLog);
 
-    return AddAdminResponse.builder().admins(
-        roleService.getAdmins().stream().map(lemmyPersonService::getPersonView).toList()).build();
+    return AddAdminResponse.builder()
+        .admins(roleService.getAdmins()
+            .stream()
+            .map(lemmyPersonService::getPersonView)
+            .toList())
+        .build();
   }
 
   @Operation(summary = "Get the unread registration applications count.")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = GetUnreadRegistrationApplicationCountResponse.class))})})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = GetUnreadRegistrationApplicationCountResponse.class))})})
   @GetMapping("registration_application/count")
   GetUnreadRegistrationApplicationCountResponse registrationApplicationCount(
       @Valid GetUnreadRegistrationApplicationCount getUnreadRegistrationApplicationCountForm,
@@ -143,17 +150,21 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionInstanceTypes.INSTANCE_REMOVE_ADMIN)
-        .check()
+
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
-    return GetUnreadRegistrationApplicationCountResponse.builder().registration_applications(
-        (int) personRegistrationApplicationRepository.countByApplicationStatus(
-            PersonRegistrationApplicationStatus.pending)).build();
+    return GetUnreadRegistrationApplicationCountResponse.builder()
+        .registration_applications(
+            (int) personRegistrationApplicationRepository.countByApplicationStatus(
+                PersonRegistrationApplicationStatus.pending))
+        .build();
   }
 
   @Operation(summary = "List the registration applications.")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ListRegistrationApplicationsResponse.class))})})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = ListRegistrationApplicationsResponse.class))})})
   @GetMapping("registration_application/list")
   ListRegistrationApplicationsResponse registrationApplicationList(
       @Valid final ListRegistrationApplications listRegistrationApplicationsForm,
@@ -163,21 +174,23 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionRegistrationApplicationTypes.REGISTRATION_APPLICATION_READ)
-        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     final List<PersonRegistrationApplication> personRegistrationApplications = personRegistrationApplicationRepository.findAllByApplicationStatus(
         PersonRegistrationApplicationStatus.pending);
 
-    return ListRegistrationApplicationsResponse.builder().registration_applications(
-        personRegistrationApplications.stream()
+    return ListRegistrationApplicationsResponse.builder()
+        .registration_applications(personRegistrationApplications.stream()
             .map(lemmyPersonRegistrationApplicationService::getPersonRegistrationApplicationView)
-            .toList()).build();
+            .toList())
+        .build();
   }
 
   @Operation(summary = "Approve a registration application.")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = RegistrationApplicationResponse.class))})})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = RegistrationApplicationResponse.class))})})
   @PutMapping("registration_application/approve")
   RegistrationApplicationResponse registrationApplicationApprove(
       @Valid final ApproveRegistrationApplication approveRegistrationApplicationForm,
@@ -188,12 +201,11 @@ public class AdminController extends AbstractLemmyApiController {
     aclService.canPerson(person)
         .performTheAction(
             RolePermissionRegistrationApplicationTypes.REGISTRATION_APPLICATION_UPDATE)
-        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     final PersonRegistrationApplication personRegistrationApplication = personRegistrationApplicationRepository.findById(
-        (long) approveRegistrationApplicationForm.id()).orElseThrow(
-        () -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+            (long) approveRegistrationApplicationForm.id())
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
             "registration_application_not_found"));
 
     personRegistrationApplication.setApplicationStatus(
@@ -205,14 +217,18 @@ public class AdminController extends AbstractLemmyApiController {
     personRegistrationApplicationService.updatePersonRegistrationApplication(
         personRegistrationApplication);
 
-    return RegistrationApplicationResponse.builder().registration_application(
-        lemmyPersonRegistrationApplicationService.getPersonRegistrationApplicationView(
-            personRegistrationApplication)).build();
+    return RegistrationApplicationResponse.builder()
+        .registration_application(
+            lemmyPersonRegistrationApplicationService.getPersonRegistrationApplicationView(
+                personRegistrationApplication))
+        .build();
   }
 
   @Operation(summary = "Purge / Delete a person from the database.")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PurgeItemResponse.class))})})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = PurgeItemResponse.class))})})
   @PostMapping("purge/person")
   PurgeItemResponse purgePerson(@Valid @RequestBody final PurgePerson purgePersonForm,
       final JwtPerson principal) {
@@ -221,7 +237,6 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionPersonTypes.PURGE_USER)
-        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     final Person personToPurge = personRepository.findById((long) purgePersonForm.person_id())
@@ -236,8 +251,10 @@ public class AdminController extends AbstractLemmyApiController {
   }
 
   @Operation(summary = "Purge / Delete a community from the database.")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PurgeItemResponse.class))})})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = PurgeItemResponse.class))})})
   @PostMapping("purge/community")
   PurgeItemResponse purgeCommunity(@Valid @RequestBody final PurgeCommunity purgeCommunityForm,
       final JwtPerson principal) {
@@ -246,15 +263,16 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionCommunityTypes.PURGE_COMMUNITY)
-        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     throw new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED);
   }
 
   @Operation(summary = "Purge / Delete a post from the database.")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PurgeItemResponse.class))})})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = PurgeItemResponse.class))})})
   @PostMapping("purge/post")
   PurgeItemResponse purgePost(@Valid @RequestBody final PurgePost purgePostForm,
       final JwtPerson principal) {
@@ -263,7 +281,6 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionPostTypes.PURGE_POST)
-        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     final Post postToPurge = postRepository.getReferenceById((long) purgePostForm.post_id());
@@ -279,8 +296,10 @@ public class AdminController extends AbstractLemmyApiController {
   }
 
   @Operation(summary = "Purge / Delete a comment from the database.")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PurgeItemResponse.class))})})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = PurgeItemResponse.class))})})
   @PostMapping("purge/comment")
   PurgeItemResponse purgeComment(@Valid @RequestBody final PurgeComment purgeCommentForm,
       final JwtPerson principal) {
@@ -289,7 +308,6 @@ public class AdminController extends AbstractLemmyApiController {
 
     aclService.canPerson(person)
         .performTheAction(RolePermissionCommentTypes.PURGE_COMMENT)
-        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "not_an_admin"));
 
     final Comment commentToPurge = commentRepository.getReferenceById(
@@ -309,6 +327,7 @@ public class AdminController extends AbstractLemmyApiController {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
     }
 
-    return PurgeItemResponse.builder().build();
+    return PurgeItemResponse.builder()
+        .build();
   }
 }

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/authentication/config/SecurityConfig.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/authentication/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 /**
  * This class represents the configuration for the security of the application. It is responsible
@@ -33,14 +34,12 @@ public class SecurityConfig {
   public SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
 
     http
-        .authorizeHttpRequests((requests) -> requests
-            .anyRequest().permitAll()
-        )
-        .sessionManagement(
-            (sessionManagement) -> sessionManagement.sessionCreationPolicy(
-                SessionCreationPolicy.STATELESS)
-        )
-        .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+        .csrf(AbstractHttpConfigurer::disable)
+        .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+        .authorizeHttpRequests((requests) -> requests.anyRequest()
+            .permitAll())
+        .sessionManagement((sessionManagement) -> sessionManagement.sessionCreationPolicy(
+            SessionCreationPolicy.STATELESS));
     return http.build();
   }
 }

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/comment/controllers/CommentController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/comment/controllers/CommentController.java
@@ -127,7 +127,6 @@ public class CommentController extends AbstractLemmyApiController {
     aclService.canPerson(person)
         .performTheAction(RolePermissionCommentTypes.CREATE_COMMENT)
         .onCommunity(post.getCommunity())
-        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
 
     if (post.isDeleted() || post.isRemoved()) {
@@ -390,7 +389,6 @@ public class CommentController extends AbstractLemmyApiController {
     aclService.canPerson(person)
         .performTheAction(roleType)
         .onCommunity(comment.getCommunity())
-        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
 
     if (createCommentLikeForm.score() == 1) {
@@ -430,7 +428,6 @@ public class CommentController extends AbstractLemmyApiController {
     aclService.canPerson(person)
         .performTheAction(RolePermissionCommentTypes.COMMENT_LIST_VOTES)
         .onCommunity(comment.getCommunity())
-        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
 
     List<CommentLike> likes = commentLikeService.getCommentLikes(comment,
@@ -469,7 +466,6 @@ public class CommentController extends AbstractLemmyApiController {
     aclService.canPerson(person)
         .performTheAction(RolePermissionCommentTypes.FAVORITE_COMMENT)
         .onCommunity(comment.getCommunity())
-        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
 
     Optional<CommentSave> commentSaveForLater = commentSaveForLaterRepository.findFirstByPersonAndComment(
@@ -524,7 +520,6 @@ public class CommentController extends AbstractLemmyApiController {
     Optional<Person> person = getOptionalPerson(principal);
     aclService.canPerson(person.orElse(null))
         .performTheAction(RolePermissionCommentTypes.READ_COMMENT)
-        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
 
     final Optional<Integer> post_id = Optional.ofNullable(getCommentsForm.post_id());
@@ -616,7 +611,7 @@ public class CommentController extends AbstractLemmyApiController {
     aclService.canPerson(person)
         .performTheAction(RolePermissionCommentTypes.REPORT_COMMENT)
         .onCommunity(comment.getCommunity())
-        .check()
+
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
 
     final CommentReport commentReport = CommentReport.builder()

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/comment/controllers/CommentModActionsController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/comment/controllers/CommentModActionsController.java
@@ -83,9 +83,14 @@ public class CommentModActionsController extends AbstractLemmyApiController {
    * @return The updated comment response.
    */
   @Operation(summary = "A moderator remove for a comment.")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CommentResponse.class))}),
-      @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ResponseStatusException.class)))})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = CommentResponse.class))}),
+      @ApiResponse(responseCode = "404",
+          description = "Not Found",
+          content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+              schema = @Schema(implementation = ResponseStatusException.class)))})
   @PostMapping("remove")
   CommentResponse remove(@Valid @RequestBody RemoveComment removeCommentForm, JwtPerson principal) {
 
@@ -112,10 +117,14 @@ public class CommentModActionsController extends AbstractLemmyApiController {
         .removed(removeCommentForm.removed())
         .entityId(comment.getId())
         .commentId(comment.getId())
-        .postId(comment.getPost().getId())
-        .communityId(comment.getCommunity().getId())
-        .instance(comment.getPost().getInstance())
-        .otherPersonId(comment.getPerson().getId())
+        .postId(comment.getPost()
+            .getId())
+        .communityId(comment.getCommunity()
+            .getId())
+        .instance(comment.getPost()
+            .getInstance())
+        .otherPersonId(comment.getPerson()
+            .getId())
         .moderationPersonId(person.getId())
         .build();
     moderationLogService.createModerationLog(moderationLog);
@@ -133,9 +142,14 @@ public class CommentModActionsController extends AbstractLemmyApiController {
    * @return The updated comment response.
    */
   @Operation(summary = "Distinguishes a comment (speak as moderator).")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CommentResponse.class))}),
-      @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ResponseStatusException.class)))})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = CommentResponse.class))}),
+      @ApiResponse(responseCode = "404",
+          description = "Not Found",
+          content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+              schema = @Schema(implementation = ResponseStatusException.class)))})
   @PostMapping("distinguish")
   CommentResponse distinguish(@Valid @RequestBody DistinguishComment distinguishCommentForm,
       JwtPerson principal) {
@@ -168,8 +182,10 @@ public class CommentModActionsController extends AbstractLemmyApiController {
    * @return The updated comment report response. (type: CommentReportResponse)
    */
   @Operation(summary = "Resolve a comment report. Only a mod can do this.")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CommentReportResponse.class))})})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = CommentReportResponse.class))})})
   @PutMapping("report/resolve")
   CommentReportResponse reportResolve(
       @Valid @RequestBody ResolveCommentReport resolveCommentReportForm, JwtPerson principal) {
@@ -188,10 +204,11 @@ public class CommentModActionsController extends AbstractLemmyApiController {
         RolePermissionInstanceTypes.REPORT_INSTANCE_RESOLVE);
 
     if (!isAdmin) {
-      final boolean isModerator =
-          linkPersonCommunityService.hasLink(person, commentReport.getComment().getCommunity(),
-              LinkPersonCommunityType.moderator) || linkPersonCommunityService.hasLink(person,
-              commentReport.getComment().getCommunity(), LinkPersonCommunityType.owner);
+      final boolean isModerator = linkPersonCommunityService.hasLink(person,
+          commentReport.getComment()
+              .getCommunity(), LinkPersonCommunityType.moderator)
+          || linkPersonCommunityService.hasLink(person, commentReport.getComment()
+          .getCommunity(), LinkPersonCommunityType.owner);
       if (!isModerator) {
         throw new ResponseStatusException(HttpStatus.FORBIDDEN);
       }
@@ -215,8 +232,10 @@ public class CommentModActionsController extends AbstractLemmyApiController {
    * @return A response containing a list of comment report views.
    */
   @Operation(summary = "List comment reports.")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ListCommentReportsResponse.class))})})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = ListCommentReportsResponse.class))})})
   @GetMapping("report/list")
   ListCommentReportsResponse reportList(@Valid ListCommentReports listCommentReportsForm,
       JwtPerson principal) {
@@ -297,6 +316,8 @@ public class CommentModActionsController extends AbstractLemmyApiController {
           commentReport.getCreator()));
     }
 
-    return ListCommentReportsResponse.builder().comment_reports(commentReportViews).build();
+    return ListCommentReportsResponse.builder()
+        .comment_reports(commentReportViews)
+        .build();
   }
 }

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/community/controllers/CommunityOwnerController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/community/controllers/CommunityOwnerController.java
@@ -62,8 +62,10 @@ public class CommunityOwnerController extends AbstractLemmyApiController {
   private final SlurFilterService slurFilterService;
 
   @Operation(summary = "Create a new community.")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CommunityResponse.class))})})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = CommunityResponse.class))})})
   @PostMapping
   @Transactional
   public CommunityResponse create(@Valid @RequestBody final CreateCommunity createCommunityForm,
@@ -71,8 +73,7 @@ public class CommunityOwnerController extends AbstractLemmyApiController {
 
     Person person = getPersonOrThrowUnauthorized(principal);
 
-    rolePermissionService.isPermitted(person,
-        RolePermissionCommunityTypes.CREATE_COMMUNITY,
+    rolePermissionService.isPermitted(person, RolePermissionCommunityTypes.CREATE_COMMUNITY,
         () -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
 
     final List<Language> languages = new ArrayList<>();
@@ -85,13 +86,15 @@ public class CommunityOwnerController extends AbstractLemmyApiController {
     }
 
     Community.CommunityBuilder communityBuilder = Community.builder()
-        .instance(localInstanceContext.instance()).title(createCommunityForm.title())
+        .instance(localInstanceContext.instance())
+        .title(createCommunityForm.title())
         .titleSlug(slugUtil.stringToSlug(createCommunityForm.name()))
-        .description(createCommunityForm.description()).isPostingRestrictedToMods(
-            createCommunityForm.posting_restricted_to_mods() != null
-                && createCommunityForm.posting_restricted_to_mods())
+        .description(createCommunityForm.description())
+        .isPostingRestrictedToMods(createCommunityForm.posting_restricted_to_mods() != null
+            && createCommunityForm.posting_restricted_to_mods())
         .isNsfw(createCommunityForm.nsfw() != null && createCommunityForm.nsfw())
-        .iconImageUrl(createCommunityForm.icon()).bannerImageUrl(createCommunityForm.banner())
+        .iconImageUrl(createCommunityForm.icon())
+        .bannerImageUrl(createCommunityForm.banner())
         .languages(languages);
 
     try {
@@ -135,10 +138,16 @@ public class CommunityOwnerController extends AbstractLemmyApiController {
     Community community = communityBuilder.build();
 
     final Set<LinkPersonCommunity> linkPersonCommunities = new LinkedHashSet<>();
-    linkPersonCommunities.add(LinkPersonCommunity.builder().community(community).person(person)
-        .linkType(LinkPersonCommunityType.owner).build());
-    linkPersonCommunities.add(LinkPersonCommunity.builder().community(community).person(person)
-        .linkType(LinkPersonCommunityType.follower).build());
+    linkPersonCommunities.add(LinkPersonCommunity.builder()
+        .community(community)
+        .person(person)
+        .linkType(LinkPersonCommunityType.owner)
+        .build());
+    linkPersonCommunities.add(LinkPersonCommunity.builder()
+        .community(community)
+        .person(person)
+        .linkType(LinkPersonCommunityType.follower)
+        .build());
 
     communityService.createCommunity(community);
 
@@ -148,10 +157,14 @@ public class CommunityOwnerController extends AbstractLemmyApiController {
   }
 
   @Operation(summary = "Edit a community.")
-  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK", content = {
-      @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CommunityResponse.class))}),
-      @ApiResponse(responseCode = "400", description = "Community Not Found", content = {
-          @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ApiError.class))})})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200",
+      description = "OK",
+      content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+          schema = @Schema(implementation = CommunityResponse.class))}),
+      @ApiResponse(responseCode = "400",
+          description = "Community Not Found",
+          content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+              schema = @Schema(implementation = ApiError.class))})})
   @PutMapping
   CommunityResponse update(@Valid final @RequestBody EditCommunity editCommunityForm,
       final JwtPerson principal) {

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/image/controllers/ImageController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/image/controllers/ImageController.java
@@ -64,6 +64,7 @@ public class ImageController extends AbstractLemmyApiController {
     final Person person = getPersonOrThrowUnauthorized(principal);
     aclService.canPerson(person)
         .performTheAction(RolePermissionMediaTypes.CREATE_MEDIA)
+        .check()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
 
     Resource resource = new ByteArrayResource(images.getBytes()) {

--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/user/controllers/UserAuthController.java
@@ -255,7 +255,7 @@ public class UserAuthController extends AbstractLemmyApiController {
       throws LemmyException {
 
     final Person person = personRepository.findOneByNameIgnoreCase(loginForm.username_or_email())
-        .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     // @todo verify password
 
     if (person.isDeleted()) {

--- a/src/main/java/com/sublinks/sublinksapi/authorization/services/AclService.java
+++ b/src/main/java/com/sublinks/sublinksapi/authorization/services/AclService.java
@@ -181,13 +181,6 @@ public class AclService {
         }
       }
 
-      execute();
-      return this;
-    }
-
-    public EntityPolicy check() {
-
-      execute();
       return this;
     }
 
@@ -198,6 +191,7 @@ public class AclService {
      */
     public boolean isPermitted() {
 
+      execute();
       return isPermitted;
     }
 
@@ -211,6 +205,7 @@ public class AclService {
     public <X extends Throwable> void orElseThrow(Supplier<? extends X> exceptionSupplier)
         throws X {
 
+      execute();
       if (!isPermitted) {
         throw exceptionSupplier.get();
       }

--- a/src/main/java/com/sublinks/sublinksapi/authorization/services/AclService.java
+++ b/src/main/java/com/sublinks/sublinksapi/authorization/services/AclService.java
@@ -210,6 +210,7 @@ public class AclService {
      */
     public <X extends Throwable> void orElseThrow(Supplier<? extends X> exceptionSupplier)
         throws X {
+
       if (!isPermitted) {
         throw exceptionSupplier.get();
       }

--- a/src/main/java/com/sublinks/sublinksapi/authorization/services/AclService.java
+++ b/src/main/java/com/sublinks/sublinksapi/authorization/services/AclService.java
@@ -5,7 +5,10 @@ import com.sublinks.sublinksapi.authorization.entities.Acl;
 import com.sublinks.sublinksapi.authorization.enums.AuthorizedEntityType;
 import com.sublinks.sublinksapi.authorization.enums.RolePermissionInterface;
 import com.sublinks.sublinksapi.authorization.repositories.AclRepository;
+import com.sublinks.sublinksapi.comment.entities.Comment;
+import com.sublinks.sublinksapi.community.entities.Community;
 import com.sublinks.sublinksapi.person.entities.Person;
+import com.sublinks.sublinksapi.post.entities.Post;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -32,20 +35,10 @@ public class AclService {
   public EntityPolicy canPerson(final Person person) {
 
     if (person == null) {
-      return new EntityPolicy(
-          ActionType.check,
-          aclRepository,
-          rolePermissionService,
-          roleService
-      );
+      return new EntityPolicy(ActionType.check, aclRepository, rolePermissionService, roleService);
     }
-    return new EntityPolicy(
-        person,
-        ActionType.check,
-        aclRepository,
-        rolePermissionService,
-        roleService
-    );
+    return new EntityPolicy(person, ActionType.check, aclRepository, rolePermissionService,
+        roleService);
   }
 
   /**
@@ -57,20 +50,10 @@ public class AclService {
   public EntityPolicy allowPerson(final Person person) {
 
     if (person == null) {
-      return new EntityPolicy(
-          ActionType.allow,
-          aclRepository,
-          rolePermissionService,
-          roleService
-      );
+      return new EntityPolicy(ActionType.allow, aclRepository, rolePermissionService, roleService);
     }
-    return new EntityPolicy(
-        person,
-        ActionType.allow,
-        aclRepository,
-        rolePermissionService,
-        roleService
-    );
+    return new EntityPolicy(person, ActionType.allow, aclRepository, rolePermissionService,
+        roleService);
   }
 
   /**
@@ -83,20 +66,10 @@ public class AclService {
   public EntityPolicy revokePerson(final Person person) {
 
     if (person == null) {
-      return new EntityPolicy(
-          ActionType.revoke,
-          aclRepository,
-          rolePermissionService,
-          roleService
-      );
+      return new EntityPolicy(ActionType.revoke, aclRepository, rolePermissionService, roleService);
     }
-    return new EntityPolicy(
-        person,
-        ActionType.revoke,
-        aclRepository,
-        rolePermissionService,
-        roleService
-    );
+    return new EntityPolicy(person, ActionType.revoke, aclRepository, rolePermissionService,
+        roleService);
   }
 
   /**
@@ -124,6 +97,7 @@ public class AclService {
     private boolean isPermitted = true;
     private AuthorizedEntityType entityType;
     private Long entityId;
+    private Community community;
 
     /**
      * The EntityPolicy class represents a policy for accessing and manipulating entities in an
@@ -132,15 +106,13 @@ public class AclService {
      * @param actionType    the type of action to be performed
      * @param aclRepository the repository for accessing and manipulating ACL entities
      */
-    public EntityPolicy(
-        final ActionType actionType,
-        final AclRepository aclRepository,
-        final RolePermissionService rolePermissionService, RoleService roleService
-    ) {
+    public EntityPolicy(final ActionType actionType, final AclRepository aclRepository,
+        final RolePermissionService rolePermissionService, RoleService roleService) {
 
       this.roleService = roleService;
 
-      this.person = Person.builder().build();
+      this.person = Person.builder()
+          .build();
       this.actionType = actionType;
       this.aclRepository = aclRepository;
       this.rolePermissionService = rolePermissionService;
@@ -154,12 +126,9 @@ public class AclService {
      * @param actionType    the type of action to be performed
      * @param aclRepository the repository for accessing and manipulating ACL entities
      */
-    public EntityPolicy(
-        final Person person,
-        final ActionType actionType,
-        final AclRepository aclRepository,
-        RolePermissionService rolePermissionService, RoleService roleService
-    ) {
+    public EntityPolicy(final Person person, final ActionType actionType,
+        final AclRepository aclRepository, RolePermissionService rolePermissionService,
+        RoleService roleService) {
 
       this.person = person;
       this.actionType = actionType;
@@ -180,6 +149,12 @@ public class AclService {
       return this;
     }
 
+    public EntityPolicy onCommunity(final Community community) {
+
+      this.community = community;
+      return this;
+    }
+
     /**
      * Executes the specified action on the provided entity and sets the entity type and ID for the
      * policy.
@@ -191,6 +166,27 @@ public class AclService {
 
       this.entityType = entity.entityType();
       this.entityId = entity.getId();
+
+      switch (entityType) {
+        case post: {
+          this.community = ((Post) entity).getCommunity();
+          break;
+        }
+        case comment: {
+          this.community = ((Comment) entity).getCommunity();
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+
+      execute();
+      return this;
+    }
+
+    public EntityPolicy check() {
+
       execute();
       return this;
     }
@@ -214,7 +210,6 @@ public class AclService {
      */
     public <X extends Throwable> void orElseThrow(Supplier<? extends X> exceptionSupplier)
         throws X {
-
       if (!isPermitted) {
         throw exceptionSupplier.get();
       }
@@ -236,28 +231,37 @@ public class AclService {
       switch (actionType) {
         case allow -> createAclRules();
         case revoke -> revokeAclRules();
-        default -> checkAclRules();
+        default -> {
+          checkAclRules();
+          checkRoles();
+        }
       }
     }
 
     /**
-     * Checks the role permissions for the current policy. If a person is associated with the
-     * policy, it checks if the person is permitted to perform the specified role permission. If no
-     * person is associated with the policy, it checks if the default guest role is permitted to
-     * perform the specified role permission.
+     * Checks the role permission for the current policy.
+     * <p>
+     * This method checks if the person associated with the policy is banned in the specified
+     * community or in general. If banned, it checks if the authorized action is allowed in the
+     * banned role to determine if the policy is permitted. If not banned, it checks if the person
+     * has the required role permission to perform the authorized action.
      */
     private void checkRolePermission() {
 
       if (this.person != null) {
-        this.isPermitted = rolePermissionService.isPermitted(
-            this.person,
-            (RolePermissionInterface) this.authorizedActions
-        );
+        if (community != null) {
+          // Only permitted if the authorized action allowed in the banned role
+          this.isPermitted = rolePermissionService.isPermitted(person,
+              (RolePermissionInterface) this.authorizedActions, community.getId());
+
+        } else {
+          this.isPermitted = rolePermissionService.isPermitted(this.person,
+              (RolePermissionInterface) this.authorizedActions);
+        }
       } else {
-        this.isPermitted = rolePermissionService.isPermitted(
-            roleService.getDefaultGuestRole(() -> new RuntimeException("No guest role defined.")),
-            (RolePermissionInterface) this.authorizedActions
-        );
+        this.isPermitted = rolePermissionService.isPermitted(roleService.getDefaultGuestRole()
+                .orElseThrow(() -> new RuntimeException("No default registered role defined.")),
+            (RolePermissionInterface) this.authorizedActions);
       }
     }
 
@@ -268,13 +272,41 @@ public class AclService {
 
       for (String authorizedAction : authorizedActions) {
         Acl acl = aclRepository.findAclByPersonIdAndEntityTypeAndEntityIdAndAuthorizedAction(
-            person.getId(), entityType, entityId, authorizedAction
-        );
+            person.getId(), entityType, entityId, authorizedAction);
         if (acl != null && !acl.isPermitted()) {
           isPermitted = false;
         }
         if (acl == null) {
           isPermitted = false;
+        }
+      }
+    }
+
+    /**
+     * Checks the roles of the current policy.
+     *
+     * <p>
+     * This method checks if the person associated with the policy is banned in the specified
+     * community or in general. If the person is banned, it checks if the authorized action is
+     * allowed in the banned role to determine if the policy is permitted. If the person is not
+     * banned, it checks if the person has the required role permission to perform the authorized
+     * action.
+     */
+    private void checkRoles() {
+
+      // Only permitted if the authorized action allowed in the banned role
+      if (this.person != null) {
+        if (RolePermissionService.isBanned(this.person)) {
+          this.isPermitted = rolePermissionService.isPermitted(roleService.getBannedRole()
+                  .orElseThrow(() -> new RuntimeException("No banned role defined.")),
+              (RolePermissionInterface) this.authorizedActions);
+        }
+        if (community != null) {
+          if (rolePermissionService.isBannedInCommunity(this.person, community.getId())) {
+            this.isPermitted = rolePermissionService.isPermitted(roleService.getBannedRole()
+                    .orElseThrow(() -> new RuntimeException("No banned role defined.")),
+                (RolePermissionInterface) this.authorizedActions);
+          }
         }
       }
     }
@@ -286,8 +318,7 @@ public class AclService {
 
       for (String authorizedAction : authorizedActions) {
         Acl acl = aclRepository.findAclByPersonIdAndEntityTypeAndEntityIdAndAuthorizedActionAndPermitted(
-            person.getId(), entityType, entityId, authorizedAction, true
-        );
+            person.getId(), entityType, entityId, authorizedAction, true);
         if (acl == null) {
           aclRepository.saveAndFlush(Acl.builder()
               .personId(person.getId())
@@ -310,8 +341,7 @@ public class AclService {
 
       for (String authorizedAction : authorizedActions) {
         Acl acl = aclRepository.findAclByPersonIdAndEntityTypeAndEntityIdAndAuthorizedActionAndPermitted(
-            person.getId(), entityType, entityId, authorizedAction, false
-        );
+            person.getId(), entityType, entityId, authorizedAction, false);
         if (acl == null) {
           aclRepository.saveAndFlush(Acl.builder()
               .personId(person.getId())

--- a/src/main/java/com/sublinks/sublinksapi/authorization/services/RolePermissionService.java
+++ b/src/main/java/com/sublinks/sublinksapi/authorization/services/RolePermissionService.java
@@ -3,7 +3,11 @@ package com.sublinks.sublinksapi.authorization.services;
 import com.sublinks.sublinksapi.authorization.entities.Role;
 import com.sublinks.sublinksapi.authorization.enums.RolePermissionInterface;
 import com.sublinks.sublinksapi.authorization.enums.RoleTypes;
+import com.sublinks.sublinksapi.community.entities.Community;
+import com.sublinks.sublinksapi.community.repositories.CommunityRepository;
 import com.sublinks.sublinksapi.person.entities.Person;
+import com.sublinks.sublinksapi.person.enums.LinkPersonCommunityType;
+import com.sublinks.sublinksapi.person.services.LinkPersonCommunityService;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -19,6 +23,8 @@ import org.springframework.stereotype.Service;
 public class RolePermissionService {
 
   private final RoleService roleService;
+  private final LinkPersonCommunityService linkPersonCommunityService;
+  private final CommunityRepository communityRepository;
 
   /**
    * Checks if a role is banned.
@@ -43,6 +49,30 @@ public class RolePermissionService {
       return false;
     }
     return isBanned(person.getRole());
+  }
+
+  /**
+   * Checks if the given person is banned in the specified community.
+   *
+   * @param person    The person to check for ban status. Cannot be null.
+   * @param community The community to check. Cannot be null.
+   * @return True if the person is banned in the community, false otherwise.
+   */
+  public boolean isBannedInCommunity(final Person person, final Community community) {
+
+    if (person == null || person.getRole() == null) {
+      return false;
+    }
+    return linkPersonCommunityService.hasLink(person, community, LinkPersonCommunityType.banned);
+  }
+
+  public boolean isBannedInCommunity(final Person person, final Long communityId) {
+
+    if (person == null || person.getRole() == null) {
+      return false;
+    }
+    final Community community = communityRepository.getReferenceById(communityId);
+    return isBannedInCommunity(person, community);
   }
 
   /**
@@ -95,12 +125,10 @@ public class RolePermissionService {
    * @param rolePermission The permission to check.
    * @return True if the person is permitted, false otherwise.
    */
-  public boolean isPermitted(final Person person,
-      final RolePermissionInterface rolePermission) {
+  public boolean isPermitted(final Person person, final RolePermissionInterface rolePermission) {
 
     final Role role = person == null ? roleService.getDefaultGuestRole(
-        () -> new RuntimeException("No Guest role found.")
-    ) : person.getRole();
+        () -> new RuntimeException("No Guest role found.")) : person.getRole();
 
     return isAdmin(role) || doesRoleHavePermission(role, rolePermission);
   }
@@ -128,7 +156,8 @@ public class RolePermissionService {
   public boolean isPermitted(@NonNull final Role role,
       final Set<RolePermissionInterface> rolePermissions) {
 
-    return rolePermissions.stream().anyMatch(x -> doesRoleHavePermission(role, x));
+    return rolePermissions.stream()
+        .anyMatch(x -> doesRoleHavePermission(role, x));
   }
 
   /**
@@ -203,14 +232,64 @@ public class RolePermissionService {
       final RolePermissionInterface rolePermission, Supplier<? extends X> exceptionSupplier)
       throws X {
 
-    final Role role = person == null ? roleService.getDefaultGuestRole(
-        () -> new RuntimeException("No Guest role found.")) : person.getRole();
-
     if (person != null && person.isDeleted()) {
       throw exceptionSupplier.get();
     }
 
+    final Role role = person == null ? roleService.getDefaultGuestRole(
+        () -> new RuntimeException("No Guest role found.")) : person.getRole();
+
     isPermitted(role, rolePermission, exceptionSupplier);
+  }
+
+  /**
+   * Checks if the given person is permitted to perform the specified role permission.
+   *
+   * @param person         The person to check. Can be null.
+   * @param rolePermission The permission to check.
+   * @param communityId    The ID of the community to check.
+   * @return True if the person is permitted, false otherwise.
+   */
+  public boolean isPermitted(final Person person, final RolePermissionInterface rolePermission,
+      final Long communityId) {
+
+    if (person != null && person.isDeleted()) {
+      return false;
+    }
+    final Role role = person == null ? roleService.getDefaultGuestRole(
+        () -> new RuntimeException("No Guest role found.")) : isBannedInCommunity(person,
+        communityId) ? this.roleService.getBannedRole()
+        .orElseThrow(() -> new RuntimeException("No Banned role found.")) : person.getRole();
+
+    return isAdmin(role) || doesRoleHavePermission(role, rolePermission);
+  }
+
+  /**
+   * Checks if the given person is permitted to perform the specified role permission.
+   *
+   * @param person            The person to check. Can be null.
+   * @param rolePermission    The permission to check.
+   * @param communityId       The ID of the community to check.
+   * @param exceptionSupplier A supplier that provides the exception to throw if the person is not
+   *                          permitted.
+   * @param <X>               The type of exception thrown.
+   * @throws X The exception provided by the exceptionSupplier if the person is not permitted.
+   */
+  public <X extends Throwable> void isPermitted(final Person person,
+      final RolePermissionInterface rolePermission, final Long communityId,
+      final Supplier<? extends X> exceptionSupplier) throws X {
+
+    if (person != null && person.isDeleted()) {
+      throw exceptionSupplier.get();
+    }
+    final Role role = person == null ? roleService.getDefaultGuestRole(
+        () -> new RuntimeException("No Guest role found.")) : isBannedInCommunity(person,
+        communityId) ? this.roleService.getBannedRole()
+        .orElseThrow(() -> new RuntimeException("No Banned role found.")) : person.getRole();
+
+    if (!isAdmin(role) || doesRoleHavePermission(role, rolePermission)) {
+      throw exceptionSupplier.get();
+    }
   }
 
   /**
@@ -226,7 +305,9 @@ public class RolePermissionService {
     if (isAdmin(role)) {
       return true;
     }
-    return role.getRolePermissions().stream()
-        .anyMatch(x -> x.getPermission().equals(rolePermission.toString()));
+    return role.getRolePermissions()
+        .stream()
+        .anyMatch(x -> x.getPermission()
+            .equals(rolePermission.toString()));
   }
 }

--- a/src/main/java/com/sublinks/sublinksapi/authorization/services/RolePermissionService.java
+++ b/src/main/java/com/sublinks/sublinksapi/authorization/services/RolePermissionService.java
@@ -11,6 +11,7 @@ import com.sublinks.sublinksapi.person.services.LinkPersonCommunityService;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
+import jakarta.validation.constraints.Null;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -256,10 +257,15 @@ public class RolePermissionService {
     if (person != null && person.isDeleted()) {
       return false;
     }
-    final Role role = person == null ? roleService.getDefaultGuestRole(
-        () -> new RuntimeException("No Guest role found.")) : isBannedInCommunity(person,
-        communityId) ? this.roleService.getBannedRole()
+    Role role = null;
+
+    if(person != null) {
+      role = isBannedInCommunity(person, communityId) ? this.roleService.getBannedRole()
         .orElseThrow(() -> new RuntimeException("No Banned role found.")) : person.getRole();
+    } else {
+      role = roleService.getDefaultGuestRole(
+        () -> new RuntimeException("No Guest role found."));
+    }
 
     return isAdmin(role) || doesRoleHavePermission(role, rolePermission);
   }


### PR DESCRIPTION
The code has been updated to add permission checks before every action on entities to enhance security. This ensures actions can only be performed by authorized users. Furthermore, some code blocks have been refactored to improve readability and maintainability. For example, the `@ApiResponses` annotations have been reformatted for better understandability.