### PR TITLE
Disable CSRF protection in SecurityConfig

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/authentication/config/SecurityConfig.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/authentication/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 /**
  * This class represents the configuration for the security of the application. It is responsible
@@ -33,14 +34,12 @@ public class SecurityConfig {
   public SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
 
     http
-        .authorizeHttpRequests((requests) -> requests
-            .anyRequest().permitAll()
-        )
-        .sessionManagement(
-            (sessionManagement) -> sessionManagement.sessionCreationPolicy(
-                SessionCreationPolicy.STATELESS)
-        )
-        .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+        .csrf(AbstractHttpConfigurer::disable)
+        .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+        .authorizeHttpRequests((requests) -> requests.anyRequest()
+            .permitAll())
+        .sessionManagement((sessionManagement) -> sessionManagement.sessionCreationPolicy(
+            SessionCreationPolicy.STATELESS));
     return http.build();
   }
 }


### PR DESCRIPTION
The changes in this commit involve deactivating the CSRF protection in the SecurityConfig.java file. This action simplifies the configuration while retaining the necessary permissions and session management. The code also becomes slightly