### PR TITLE
Fix pagination to start from page 1 instead of 0.

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/post/services/PostSearchQueryService.java
+++ b/src/main/java/com/sublinks/sublinksapi/post/services/PostSearchQueryService.java
@@ -70,7 +70,7 @@ public class PostSearchQueryService {
 
     public Results setPage(final Integer page) {
 
-      int p = Math.max(Math.abs(page), 0);
+      int p = Math.max(Math.abs(page), 1);
       getQuery().setFirstResult((p - 1) * this.getPerPage());
       return this;
     }


### PR DESCRIPTION
Previously, the pagination logic treated negative and zero page indices the same, defaulting to 0. This change ensures that the first page starts from 1, aligning with typical pagination conventions.